### PR TITLE
Implemented player skins

### DIFF
--- a/dragonfly/player/skin/cape.go
+++ b/dragonfly/player/skin/cape.go
@@ -1,0 +1,68 @@
+package skin
+
+import (
+	"errors"
+	"image"
+	"image/color"
+)
+
+// Cape represents the cape that a skin may additionally have. A skin is of a fixed size (always 32x64 bytes)
+// and may be either empty or of that size.
+type Cape struct {
+	// Pix holds the colour data of the cape in an RGBA byte array, similarly to the way that the pixels of
+	// a Skin are stored.
+	// The size of Pix is always 32 * 64 * 4 bytes.
+	Pix []uint8
+}
+
+// NewCape initialises a new Cape with the correct size of the Pix byte slice. The pixels themselves are
+// filled with zero bytes.
+func NewCape() Cape {
+	return Cape{Pix: make([]uint8, 32*64*4)}
+}
+
+// NewCapeFromBytes creates a new Cape from the byte slice passed. The cape returned will be initialised with
+// this data, provided it is of the correct size (either 64x32 or 0x0). If it is not, an error is returned.
+func NewCapeFromBytes(p []uint8) (Cape, error) {
+	if len(p) != 0 && len(p) != 64*32*4 {
+		return Cape{}, errors.New("cape dimensions must be either 0x0 or 64x32")
+	}
+	return Cape{Pix: p}, nil
+}
+
+// Exists checks if the cape exists. In other words, it checks if the skin data is not empty.
+func (c Cape) Exists() bool {
+	return len(c.Pix) != 0
+}
+
+// ColorModel ...
+func (c Cape) ColorModel() color.Model {
+	return color.RGBAModel
+}
+
+// Bounds returns the bounds of the cape, which is always 32x64 or 0x0, depending on if the cape has any data
+// in it.
+func (c Cape) Bounds() image.Rectangle {
+	if !c.Exists() {
+		return image.Rectangle{}
+	}
+	return image.Rectangle{
+		Max: image.Point{X: 32, Y: 64},
+	}
+}
+
+// At returns the colour at a given position in the cape, provided the X and Y are within the bounds,
+// 0 <= x < 32 and 0 <= y < 64, and the cape exists.
+// The concrete type returned by At is a color.RGBA value.
+func (c Cape) At(x, y int) color.Color {
+	if x < 0 || y < 0 || x >= 32 || y >= 64 || !c.Exists() {
+		panic("pixel coordinates out of bounds")
+	}
+	offset := x*4 + 32*y*4
+	return color.RGBA{
+		R: c.Pix[offset],
+		G: c.Pix[offset+1],
+		B: c.Pix[offset+2],
+		A: c.Pix[offset+3],
+	}
+}

--- a/dragonfly/player/skin/skin.go
+++ b/dragonfly/player/skin/skin.go
@@ -1,0 +1,100 @@
+package skin
+
+import (
+	"errors"
+	"github.com/google/uuid"
+	"image"
+	"image/color"
+)
+
+// Skin holds the data of a skin that a player has equipped. It includes geometry data, the texture and the
+// cape, if one is present.
+// Skin implements the image.Image interface to ease working with the value as an image.
+type Skin struct {
+	w, h int
+	// Pix holds the raw pixel data of the skin. This is an RGBA byte slice, meaning that every first byte is
+	// a Red value, the second a Green value, the third a Blue value and the fourth an Alpha value.
+	Pix []uint8
+	// ID holds the ID of the skin. Typically, this ID carries some UUID in it to ensure a unique ID is picked
+	// for the skin.
+	ID string
+	// ModelName holds the name of the model of the skin. This name is used to identify the model, and the
+	// model is cached client-side by this name.
+	ModelName string
+	// Model holds the raw JSON data that represents the model of the skin. If empty, it means the skin holds
+	// the standard skin data (geometry.humanoid).
+	Model []byte
+	// Cape holds the cape of the skin. By default, an empty cape is set in the skin. Cape.Exists() may be
+	// called to check if the cape actually has any data.
+	Cape Cape
+}
+
+// New creates a new skin using the width and height passed. The dimensions passed must be either 64x32,
+// 64x64 or 128x128. An error is returned if other dimensions are used.
+// The skin pixels are initialised for the skin, and a random skin ID is picked. The model name and model is
+// left empty.
+func New(width, height int) (Skin, error) {
+	switch {
+	case width == 64 && height == 32:
+	case width == 64 && height == 64:
+	case width == 128 && height == 128:
+	default:
+		return Skin{}, errors.New("skin dimensions must be either 64x32, 64x64 or 128x128")
+	}
+	return Skin{
+		w:   width,
+		h:   height,
+		Pix: make([]uint8, width*height*4),
+		ID:  uuid.New().String(),
+	}, nil
+}
+
+// NewFromBytes creates a new skin from the raw skin data passed.
+func NewFromBytes(p []uint8) (Skin, error) {
+	var width, height int
+	switch len(p) {
+	case 64 * 32 * 4:
+		width, height = 64, 32
+	case 64 * 64 * 4:
+		width, height = 64, 64
+	case 128 * 128 * 4:
+		width, height = 128, 128
+	default:
+		return Skin{}, errors.New("skin dimensions must be either 64x32, 64x64 or 128x128")
+	}
+	return Skin{
+		w:   width,
+		h:   height,
+		Pix: p,
+		ID:  uuid.New().String(),
+	}, nil
+}
+
+// Bounds returns the bounds of the skin. These are either 64x32, 64x64 or 128, depending on the bounds of the
+// skin of the player.
+func (s Skin) Bounds() image.Rectangle {
+	return image.Rectangle{
+		Max: image.Point{X: s.w, Y: s.h},
+	}
+}
+
+// ColorModel returns color.RGBAModel.
+func (s Skin) ColorModel() color.Model {
+	return color.RGBAModel
+}
+
+// At returns the colour at a given position in the skin. The concrete value of the colour returned is an
+// color.RGBA value.
+// If the x or y values exceed the bounds of the skin, At will panic.
+func (s Skin) At(x, y int) color.Color {
+	if x < 0 || y < 0 || x >= s.w || y >= s.h {
+		panic("pixel coordinates out of bounds")
+	}
+	offset := x*4 + s.w*y*4
+	return color.RGBA{
+		R: s.Pix[offset],
+		G: s.Pix[offset+1],
+		B: s.Pix[offset+2],
+		A: s.Pix[offset+3],
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/go-gl/mathgl v0.0.0-20190713194549-592312d8590a
+	github.com/google/uuid v1.1.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pelletier/go-toml v1.4.0
 	github.com/sandertv/gophertunnel v1.2.5


### PR DESCRIPTION
This merge request adds API to get the skin from a player. It provides a Skin and Cape type, both of which implement the image.Image interface so that they may be directly encoded as an image.