### PR TITLE
Implemented basic chunks and chunk sending

### DIFF
--- a/dragonfly/world/chunk/block_storage.go
+++ b/dragonfly/world/chunk/block_storage.go
@@ -1,0 +1,167 @@
+package chunk
+
+const (
+	// uint32ByteSize is the amount of bytes in a uint32.
+	uint32ByteSize = 4
+	// uint32BitSize is the amount of bits in a uint32.
+	uint32BitSize = uint32ByteSize * 8
+)
+
+// BlockStorage is a storage of 4096 blocks encoded in a variable amount of uint32s, storages may have blocks
+// with a bit size per block of 1, 2, 3, 4, 5, 6, 8 or 16 bits.
+// 3 of these formats have additional padding in every uint32 and an additional uint32 at the end, to cater
+// for the blocks that don't fit. This padding is present when the storage has a block size of 3, 5 or 6
+// bytes.
+// Methods on BlockStorage must not be called simultaneously from multiple goroutines.
+type BlockStorage struct {
+	// bitsPerBlock is the amount of bits required to store one block. The number increases as the block
+	// storage holds more unique block states.
+	bitsPerBlock uint16
+	// palette holds all block runtime IDs that the blocks in the blocks slice point to. These runtime IDs
+	// point to block states.
+	palette *palette
+
+	// blocks contains all blocks in the block storage. This slice has a variable size, but may not be changed
+	// unless the whole block storage is resized, including the palette.
+	blocks []uint32
+}
+
+// NewBlockStorage creates a new block storage using the uint32 slice as the blocks and the palette passed.
+// The bits per block are calculated using the length of the uint32 slice.
+func newBlockStorage(blocks []uint32, palette *palette) *BlockStorage {
+	return &BlockStorage{blocks: blocks, bitsPerBlock: uint16(len(blocks) / uint32BitSize / uint32ByteSize), palette: palette}
+}
+
+// RuntimeID returns the runtime ID of the block located at the given x, y and z.
+func (storage *BlockStorage) RuntimeID(x, y, z byte) uint32 {
+	return storage.palette.RuntimeID(storage.paletteOffset(x&15, y&15, z&15))
+}
+
+// SetRuntimeID sets the given runtime ID at the given x, y and z. The palette and block storage are expanded
+// automatically to make space for the runtime ID, should that be needed.
+func (storage *BlockStorage) SetRuntimeID(x, y, z byte, runtimeID uint32) {
+	index := storage.palette.Index(runtimeID)
+	if index == -1 {
+		// The runtime ID was not yet available in the palette. We add it, then check if the block storage
+		// needs to be resized for the palette pointers to fit.
+		index = int(storage.palette.Add(runtimeID))
+
+		if storage.palette.needsResize() {
+			storage.palette.increaseSize()
+			storage.resize(storage.palette.size)
+		}
+	}
+	storage.setPaletteOffset(x&15, y&15, z&15, uint16(index))
+}
+
+// paletteOffset looks up the palette offset at a given x, y and z value in the block storage. This palette
+// offset is not the runtime ID at this offset, but merely an offset in the palette, pointing to a runtime ID.
+func (storage *BlockStorage) paletteOffset(x, y, z byte) uint16 {
+	uint32Offset, bitOffset := storage.offsets(x, y, z)
+	return extractUint16(storage.blocks[uint32Offset], bitOffset, storage.bitsPerBlock)
+}
+
+// setPaletteOffset sets the palette offset at a given x, y and z to paletteOffset. This offset should point
+// to a runtime ID in the block storage's palette.
+func (storage *BlockStorage) setPaletteOffset(x, y, z byte, paletteOffset uint16) {
+	uint32Offset, bitOffset := storage.offsets(x, y, z)
+	setUint16(&storage.blocks[uint32Offset], bitOffset, storage.bitsPerBlock, paletteOffset)
+}
+
+// resize resizes a block storage to palette size newPaletteSize. A new block storage is constructed, and all
+// blocks available in the current storage are set in their appropriate locations in the new storage.
+func (storage *BlockStorage) resize(newPaletteSize paletteSize) {
+	if newPaletteSize == paletteSize(storage.bitsPerBlock) {
+		return // Don't resize if the size is already equal.
+	}
+
+	const subChunkBlockCount = 16 * 16 * 16
+	requiredUint32s := subChunkBlockCount / int(uint32BitSize/newPaletteSize)
+	if newPaletteSize == 3 || newPaletteSize == 5 || newPaletteSize == 6 {
+		// Add one uint32 if the palette size is one of the padded sizes.
+		requiredUint32s++
+	}
+	n := make([]uint32, requiredUint32s)
+
+	// Construct a new block storage, set all blocks in there manually. We can't easily do this in a better
+	// way, because all blocks will be at a different offset with a different length.
+	newStorage := newBlockStorage(n, storage.palette)
+	for x := byte(0); x < 16; x++ {
+		for y := byte(0); y < 16; y++ {
+			for z := byte(0); z < 16; z++ {
+				newStorage.setPaletteOffset(x, y, z, storage.paletteOffset(x, y, z))
+			}
+		}
+	}
+	// Set the new storage.
+	*storage = *newStorage
+}
+
+// offsets calculates the word offset from a given x, y and z and returns it, along with the bit offset
+// this position is in in the word at wordOffset.
+func (storage *BlockStorage) offsets(x, y, z byte) (wordOffset uint16, bitOffset uint16) {
+	// Offset is the offset in bits that the X, Y and Z result in.
+	offset := storage.offset(x, y, z) * storage.bitsPerBlock
+	return offset / storage.filledBitsPerWord(), offset % storage.filledBitsPerWord()
+}
+
+// filledBitsPerWord calculates the filled bits per uint32 using the bits per block of a block storage. This
+// will always be equal to 32, unless the format is padded, in which case it returns 30.
+func (storage *BlockStorage) filledBitsPerWord() uint16 {
+	return uint32BitSize / storage.bitsPerBlock * storage.bitsPerBlock
+}
+
+// offset calculates the offset at which an x, y and z are stored in the block storage. The x, y and z are
+// automatically converted to block storage relative values. (0-15)
+func (storage *BlockStorage) offset(x, y, z byte) uint16 {
+	return (uint16(x) << 8) | (uint16(z) << 4) | uint16(y)
+}
+
+// compact clears unused indexes in the palette by scanning for usages in the block storage. This is a
+// relatively heavy task which should only happen right before the sub chunk holding this block storage is
+// saved to disk.
+func (storage *BlockStorage) compact() {
+	usedIndices := make([]bool, storage.palette.Len())
+	for x := byte(0); x < 16; x++ {
+		for y := byte(0); y < 16; y++ {
+			for z := byte(0); z < 16; z++ {
+				usedIndices[storage.paletteOffset(x, y, z)] = true
+			}
+		}
+	}
+	newRuntimeIDs := make([]uint32, 0, len(usedIndices))
+	conversion := make([]uint16, len(usedIndices))
+
+	for index, set := range usedIndices {
+		if set {
+			conversion[index] = uint16(len(newRuntimeIDs))
+			newRuntimeIDs = append(newRuntimeIDs, storage.palette.blockRuntimeIDs[index])
+		}
+	}
+	for x := byte(0); x < 16; x++ {
+		for y := byte(0); y < 16; y++ {
+			for z := byte(0); z < 16; z++ {
+				// Replace all usages of the old palette indexes with the new indexes using the map we
+				// produced earlier.
+				storage.setPaletteOffset(x, y, z, conversion[storage.paletteOffset(x, y, z)])
+			}
+		}
+	}
+	storage.palette.blockRuntimeIDs = newRuntimeIDs
+}
+
+// extractUint16 extracts a uint16 from a uint32 at offset, with a bit length per block of bpb.
+func extractUint16(word uint32, offset uint16, bpb uint16) uint16 {
+	return uint16((word >> offset) & (1<<bpb - 1))
+}
+
+// setUint16 sets a uint16 in a uint32 at offset, with a bit length per block of bpb.
+func setUint16(x *uint32, offset, bpb, block uint16) {
+	for i := uint16(0); i < bpb; i++ {
+		if (block & (1 << i)) != 0 {
+			*x |= uint32(1 << (i + offset))
+		} else {
+			*x &^= uint32(1 << (i + offset))
+		}
+	}
+}

--- a/dragonfly/world/chunk/chunk.go
+++ b/dragonfly/world/chunk/chunk.go
@@ -1,0 +1,75 @@
+package chunk
+
+// Chunk is a segment in the world with a size of 16x16x256 blocks. A chunk contains multiple sub chunks
+// and stores other information such as biomes.
+// It is not safe to call methods on Chunk simultaneously from multiple goroutines.
+type Chunk struct {
+	// sub holds all sub chunks part of the chunk. The pointers held by the array are nil if no sub chunk is
+	// allocated at the indices.
+	sub [16]*SubChunk
+	// biomes is an array of biome IDs. There is one biome ID for every column in the chunk.
+	biomes [256]uint8
+}
+
+// Sub returns the sub chunk at the given y, which is a number from 0-15. If the number is higher than that,
+// the y value will 'overflow' and return the sub chunk at y % 16.
+// If a sub chunk at this y is not present, nil is returned.
+func (chunk *Chunk) Sub(y uint8) *SubChunk {
+	return chunk.sub[y&15]
+}
+
+// BiomeID returns the biome ID at a specific column in the chunk.
+func (chunk *Chunk) BiomeID(x, z uint8) uint8 {
+	return chunk.biomes[columnOffset(x, z)]
+}
+
+// SetBiomeID sets the biome ID at a specific column in the chunk.
+func (chunk *Chunk) SetBiomeID(x, z, biomeID uint8) {
+	chunk.biomes[columnOffset(x, z)] = biomeID
+}
+
+// RuntimeID returns the runtime ID of the block at a given x, y and z in a chunk at the given layer. If no
+// sub chunk exists at the given y, the block is assumed to be air.
+func (chunk *Chunk) RuntimeID(x, y, z uint8, layer uint8) uint32 {
+	subChunkY := y >> 4
+	for i := byte(0); i <= subChunkY; i++ {
+		// The sub chunk was not initialised, so we can conclude that the block at that location would be
+		// an air block. (always runtime ID 0)
+		if chunk.sub[i] == nil {
+			return 0
+		}
+	}
+	return chunk.sub[subChunkY].Layer(layer).RuntimeID(x, y, z)
+}
+
+// SetRuntimeID sets the runtime ID of a block at a given x, y and z in a chunk at the given layer. If no
+// SubChunk exists at the given y, a new SubChunk is created and the block is set.
+func (chunk *Chunk) SetRuntimeID(x, y, z uint8, layer uint8, runtimeID uint32) {
+	i := y >> 4
+	if chunk.sub[i] == nil {
+		chunk.sub[i] = &SubChunk{}
+		// Initialise the first layer of the SubChunk.
+		chunk.sub[i].Layer(layer)
+	}
+	chunk.sub[i].Layer(layer).SetRuntimeID(x, y, z, runtimeID)
+}
+
+// Compact compacts the chunk as much as possible, getting rid of any sub chunks that are empty, and compacts
+// all storages in the sub chunks to occupy as little space as possible.
+// Compact should be called right before the chunk is saved in order to optimise the storage space.
+func (chunk *Chunk) Compact() {
+	for i, sub := range chunk.sub {
+		if sub == nil {
+			continue
+		}
+		sub.compact()
+		if len(sub.storages) == 0 {
+			chunk.sub[i] = nil
+		}
+	}
+}
+
+// columnOffset returns the offset in a byte slice that the column at a specific x and z may be found.
+func columnOffset(x, z uint8) uint8 {
+	return (x & 15) | (z&15)<<4
+}

--- a/dragonfly/world/chunk/data.go
+++ b/dragonfly/world/chunk/data.go
@@ -1,0 +1,67 @@
+package chunk
+
+import (
+	"bytes"
+	"encoding/binary"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"sync"
+)
+
+const (
+	// SubChunkVersion is the current version of the written sub chunks, specifying the format they are
+	// written as over network and on disk.
+	SubChunkVersion = 8
+)
+
+// SerialisedData holds the serialised data of a chunk. It consists of the chunk's block data itself, a height
+// map, the biomes and entities and block entities.
+type SerialisedData struct {
+	// sub holds the data of the serialised sub chunks in a chunk. Sub chunks that are empty or that otherwise
+	// don't exist are represented as an empty slice (or technically, nil).
+	SubChunks [16][]byte
+	// Data2D is the 2D data of the chunk, which is composed of the biome IDs (256 bytes) and optionally the
+	// height map of the chunk.
+	Data2D []byte
+	// BlockNBT is an encoded NBT array of all blocks that carry additional NBT, such as chests, with all
+	// their contents.
+	BlockNBT []byte
+}
+
+// pool is used to pool byte buffers used for encoding chunks.
+var pool = sync.Pool{
+	New: func() interface{} {
+		return bytes.NewBuffer(make([]byte, 0, 1024))
+	},
+}
+
+// NetworkEncode encodes a chunk passed to its network representation and returns it as a SerialisedData,
+// which may be sent over network.
+func NetworkEncode(c *Chunk) (d SerialisedData) {
+	buf := pool.Get().(*bytes.Buffer)
+
+	for y, sub := range c.sub {
+		if sub == nil {
+			// No need to put empty sub chunks in the SerialisedData.
+			continue
+		}
+		_ = buf.WriteByte(SubChunkVersion)
+		_ = buf.WriteByte(byte(len(sub.storages)))
+		for _, storage := range sub.storages {
+			_ = buf.WriteByte(byte(storage.bitsPerBlock<<1) | 1)
+			for _, word := range storage.blocks {
+				_ = binary.Write(buf, binary.LittleEndian, word)
+			}
+			_ = protocol.WriteVarint32(buf, int32(storage.palette.Len()))
+			for _, runtimeID := range storage.palette.blockRuntimeIDs {
+				_ = protocol.WriteVarint32(buf, int32(runtimeID))
+			}
+		}
+		d.SubChunks[y] = make([]byte, buf.Len())
+		_, _ = buf.Read(d.SubChunks[y])
+	}
+	d.Data2D = append(c.biomes[:], 0)
+
+	buf.Reset()
+	pool.Put(buf)
+	return
+}

--- a/dragonfly/world/chunk/palette.go
+++ b/dragonfly/world/chunk/palette.go
@@ -1,0 +1,59 @@
+package chunk
+
+// paletteSize is the size of a palette. It indicates the amount of bits occupied per block saved.
+type paletteSize byte
+
+// palette is a palette of runtime IDs that every block storage has. Block storages hold 'pointers' to indexes
+// in this palette.
+type palette struct {
+	size paletteSize
+	// blockRuntimeIDs is a map of runtime IDs. The block storages point to the index to this runtime ID.
+	blockRuntimeIDs []uint32
+}
+
+// newPalette returns a new palette with size and a slice of added runtime IDs.
+func newPalette(size paletteSize, runtimeIDs []uint32) *palette {
+	return &palette{size: size, blockRuntimeIDs: runtimeIDs}
+}
+
+// Len returns the amount of unique block runtime IDs in the palette.
+func (palette *palette) Len() int {
+	return len(palette.blockRuntimeIDs)
+}
+
+// Add adds a runtime ID to the palette. It does not check if the runtime ID was already set in the palette.
+// The index at which the runtime ID was added is returned.
+func (palette *palette) Add(runtimeID uint32) uint16 {
+	palette.blockRuntimeIDs = append(palette.blockRuntimeIDs, runtimeID)
+	return uint16(len(palette.blockRuntimeIDs) - 1)
+}
+
+// Index loops through the runtime IDs of the palette and looks for the index of the given runtime ID. If the
+// runtime ID can not be found, -1 is returned.
+func (palette *palette) Index(runtimeID uint32) int {
+	for i, id := range palette.blockRuntimeIDs {
+		if id == runtimeID {
+			return i
+		}
+	}
+	return -1
+}
+
+// RuntimeID returns the runtime ID at the palette index given.
+func (palette *palette) RuntimeID(paletteIndex uint16) uint32 {
+	return palette.blockRuntimeIDs[paletteIndex]
+}
+
+// needsResize checks if the palette and with it the holding block storage needs to be resized to a bigger
+// size.
+func (palette *palette) needsResize() bool {
+	return len(palette.blockRuntimeIDs) > (1 << palette.size)
+}
+
+var sizes = [...]paletteSize{1, 2, 3, 4, 5, 6, 8, 16}
+var offsets = [...]int{1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5, 8: 6, 16: 7}
+
+// increaseSize increases the size of the palette to the next palette size.
+func (palette *palette) increaseSize() {
+	palette.size = sizes[offsets[palette.size]+1]
+}

--- a/dragonfly/world/chunk/position.go
+++ b/dragonfly/world/chunk/position.go
@@ -1,0 +1,7 @@
+package chunk
+
+// Position holds the position of a chunk. The type is provided as a utility struct for keeping track of a
+// chunk's position. Chunks do not themselves keep track of that.
+type Position struct {
+	X, Z int32
+}

--- a/dragonfly/world/chunk/sub_chunk.go
+++ b/dragonfly/world/chunk/sub_chunk.go
@@ -1,0 +1,44 @@
+package chunk
+
+// SubChunk is a cube of blocks located in a chunk. It has a size of 16x16x16 blocks and forms part of a stack
+// that forms a Chunk.
+type SubChunk struct {
+	storages []*BlockStorage
+}
+
+// Layer returns a certain block storage/layer from a sub chunk. If no storage at the layer exists, the layer
+// is created, as well as all layers between the current highest layer and the new highest layer.
+func (subChunk *SubChunk) Layer(layer uint8) *BlockStorage {
+	for uint8(len(subChunk.storages)) <= layer {
+		// Keep appending to storages until the requested layer is achieved. Makes working with new layers
+		// much easier.
+		subChunk.storages = append(subChunk.storages, newBlockStorage(make([]uint32, 128), newPalette(1, []uint32{0})))
+	}
+	return subChunk.storages[layer]
+}
+
+// RuntimeID returns the runtime ID of the block located at the given X, Y and Z. X, Y and Z must be in a
+// range of 0-15.
+func (subChunk *SubChunk) RuntimeID(x, y, z byte, layer uint8) uint32 {
+	return subChunk.Layer(layer).RuntimeID(x, y, z)
+}
+
+// SetRuntimeID sets the given runtime ID at the given X, Y and Z. X, Y and Z must be in a range of 0-15.
+func (subChunk *SubChunk) SetRuntimeID(x, y, z byte, layer uint8, runtimeID uint32) {
+	subChunk.Layer(layer).SetRuntimeID(x, y, z, runtimeID)
+}
+
+// Compact cleans the garbage from all block storages that sub chunk contains, so that they may be
+// cleanly written to a database.
+func (subChunk *SubChunk) compact() {
+	newStorages := make([]*BlockStorage, 0, len(subChunk.storages))
+	for _, storage := range subChunk.storages {
+		storage.compact()
+		if len(storage.palette.blockRuntimeIDs) == 1 && storage.palette.blockRuntimeIDs[0] == 0 {
+			// If the palette has only air in it, it means the storage is empty, so we can ignore it.
+			continue
+		}
+		newStorages = append(newStorages, storage)
+	}
+	subChunk.storages = newStorages
+}


### PR DESCRIPTION
This merge request adds a `chunk` package which implements chunks. Chunks themselves are rather low-level abstract structures: They don't work directly with blocks, but instead only with block runtime IDs.

The main structure of a chunk is as follows:
Chunk:
    0-16 Sub chunks:
        0-256 Block storages:
            Runtime ID palette
            Pointers to the palette, representing blocks

The block storages of each sub chunk hold a palette, which in turn holds all block runtime IDs used in that storage. The storage then has 4096 pointers to runtime IDs in that palette. The size of these pointers varies, depending on how many unique blocks there are in the palette. They will have a size of either 1, 2, 3, 4, 5, 6, 8 or 16 bits, where the sizes 3, 5 and 6 have additional padding.