### PR TITLE
Time implementation

### DIFF
--- a/dragonfly/player/player.go
+++ b/dragonfly/player/player.go
@@ -41,10 +41,9 @@ type Player struct {
 
 // New returns a new initialised player. A random UUID is generated for the player, so that it may be
 // identified over network.
-func New(name string) *Player {
-	s, _ := skin.New(64, 32)
+func New(name string, skin skin.Skin) *Player {
 	// TODO: Add a way to change the world of a player once created without session. Might need a function like entity.Move for re-usability.
-	return &Player{name: name, h: NopHandler{}, uuid: uuid.New(), skin: s}
+	return &Player{name: name, h: NopHandler{}, uuid: uuid.New(), skin: skin}
 }
 
 // NewWithSession returns a new player for a network session, so that the network session can control the
@@ -52,7 +51,7 @@ func New(name string) *Player {
 // A set of additional fields must be provided to initialise the player with the client's data, such as the
 // name and the skin of the player.
 func NewWithSession(name, xuid string, uuid uuid.UUID, skin skin.Skin, s *session.Session, w *world.World) *Player {
-	p := New(name)
+	p := New(name, skin)
 	p.s = s
 	p.uuid = uuid
 	p.xuid = xuid

--- a/dragonfly/server.go
+++ b/dragonfly/server.go
@@ -60,6 +60,8 @@ func New(c *Config, log *logrus.Logger) (*Server, error) {
 	if c != nil {
 		s.c = *c
 	}
+
+	log.Debug("Loading world...")
 	p, err := mcdb.New(s.c.World.Folder)
 	if err != nil {
 		return nil, fmt.Errorf("error loading world: %v", err)
@@ -248,6 +250,7 @@ func (server *Server) handleConn(conn *minecraft.Conn) {
 		// We set these IDs to 1, because that's how the session will treat them.
 		EntityUniqueID:  1,
 		EntityRuntimeID: 1,
+		Time:            int64(server.world.Time()),
 	}
 	if err := conn.StartGame(data); err != nil {
 		_ = server.listener.Disconnect(conn, "Connection timeout.")

--- a/dragonfly/session/world.go
+++ b/dragonfly/session/world.go
@@ -165,6 +165,11 @@ func (s *Session) ViewEntityMovement(e world.Entity, deltaPos mgl32.Vec3, deltaY
 	}
 }
 
+// ViewTime ...
+func (s *Session) ViewTime(time int) {
+	s.writePacket(&packet.SetTime{Time: int32(time)})
+}
+
 // entityRuntimeID returns the runtime ID of the entity passed.
 func (s *Session) entityRuntimeID(e world.Entity) uint64 {
 	s.entityMutex.RLock()

--- a/dragonfly/world/mcdb/provider.go
+++ b/dragonfly/world/mcdb/provider.go
@@ -62,6 +62,30 @@ func (p *Provider) initDefaultLevelDat() {
 	p.d.GameType = 2
 }
 
+// LoadTime returns the time as it was stored in the level.dat of the world loaded.
+func (p *Provider) LoadTime() int64 {
+	return p.d.Time
+}
+
+// SaveTime saves the time to the level.dat of the world.
+func (p *Provider) SaveTime(time int64) {
+	p.d.Time = time
+}
+
+// LoadTimeCycle returns whether the time is cycling or not.
+func (p *Provider) LoadTimeCycle() bool {
+	return p.d.DoDayLightCycle == 1
+}
+
+// SaveTimeCycle saves the state of the time cycle, either running or stopped, to the level.dat.
+func (p *Provider) SaveTimeCycle(running bool) {
+	if running {
+		p.d.DoDayLightCycle = 1
+		return
+	}
+	p.d.DoDayLightCycle = 0
+}
+
 // WorldName returns the name of the world that the provider provides data for.
 func (p *Provider) WorldName() string {
 	return p.d.LevelName

--- a/dragonfly/world/provider.go
+++ b/dragonfly/world/provider.go
@@ -32,11 +32,37 @@ type Provider interface {
 	// SaveEntities saves a list of entities in a chunk position. If writing is not successful, an error is
 	// returned.
 	SaveEntities(position ChunkPos, entities []Entity) error
+	// LoadTime loads the time of the world.
+	LoadTime() int64
+	// SaveTime saves the time of the world.
+	SaveTime(time int64)
+	// SaveTimeCycle saves the state of the time cycle: Either stopped or started. If true is passed, the time
+	// is running. If false, the time is stopped.
+	SaveTimeCycle(running bool)
+	// LoadTimeCycle loads the state of the time cycle: If time is running, true is returned. If the time
+	// cycle is stopped, false is returned.
+	LoadTimeCycle() bool
 }
 
 // NoIOProvider implements a Provider while not performing any disk I/O. It generates values on the run and
 // dynamically, instead of reading and writing data, and returns otherwise empty values.
 type NoIOProvider struct{}
+
+// SaveTimeCycle ...
+func (p NoIOProvider) SaveTimeCycle(running bool) {}
+
+// LoadTimeCycle ...
+func (p NoIOProvider) LoadTimeCycle() bool {
+	return true
+}
+
+// LoadTime ...
+func (p NoIOProvider) LoadTime() int64 {
+	return 0
+}
+
+// SaveTime ...
+func (p NoIOProvider) SaveTime(time int64) {}
 
 // LoadEntities ...
 func (p NoIOProvider) LoadEntities(position ChunkPos) ([]Entity, error) {

--- a/dragonfly/world/viewer.go
+++ b/dragonfly/world/viewer.go
@@ -20,4 +20,7 @@ type Viewer interface {
 	// ViewChunk views the chunk passed at a particular position. It is called for every chunk loaded using
 	// the world.Loader.
 	ViewChunk(pos ChunkPos, c *chunk.Chunk)
+	// ViewTime views the time of the world. It is called every time the time is changed or otherwise every
+	// second.
+	ViewTime(time int)
 }


### PR DESCRIPTION
This PR implements time in Dragonfly: There is now API for time changing and stopping, and Dragonfly will, by default, have a working day-night cycle. These properties are also saved to the provider.