### PR TITLE
call block.EntityInsider.EntityInside() for all entities

### DIFF
--- a/server/entity/movement.go
+++ b/server/entity/movement.go
@@ -78,7 +78,7 @@ func (c *MovementComputer) TickMovement(e world.Entity, pos, vel mgl64.Vec3, rot
 
 // checkEntityInsiders checks if the entity is colliding with any EntityInsider blocks.
 func (c *MovementComputer) checkEntityInsiders(ent world.Entity, tx *world.Tx) {
-	box := ent.H().Type().BBox(ent).Grow(-0.0001)
+	box := ent.H().Type().BBox(ent).Translate(ent.Position()).Grow(-0.0001)
 	low, high := cube.PosFromVec3(box.Min()), cube.PosFromVec3(box.Max())
 
 	for y := low[1]; y <= high[1]; y++ {

--- a/server/entity/movement.go
+++ b/server/entity/movement.go
@@ -77,7 +77,7 @@ func (c *MovementComputer) TickMovement(e world.Entity, pos, vel mgl64.Vec3, rot
 }
 
 // checkEntityInsiders checks if the entity is colliding with any EntityInsider blocks.
-func (m *Movement) checkEntityInsiders(ent world.Entity, tx *world.Tx) {
+func (c *MovementComputer) checkEntityInsiders(ent world.Entity, tx *world.Tx) {
 	box := ent.H().Type().BBox(ent).Grow(-0.0001)
 	low, high := cube.PosFromVec3(box.Min()), cube.PosFromVec3(box.Max())
 
@@ -149,6 +149,8 @@ func (c *MovementComputer) applyHorizontalForces(tx *world.Tx, pos, vel mgl64.Ve
 func (c *MovementComputer) checkCollision(tx *world.Tx, e world.Entity, pos, vel mgl64.Vec3) (mgl64.Vec3, mgl64.Vec3) {
 	// TODO: Implement collision with other entities.
 	deltaX, deltaY, deltaZ := vel[0], vel[1], vel[2]
+
+	c.checkEntityInsiders(e, tx)
 
 	// Entities only ever have a single bounding box.
 	entityBBox := e.H().Type().BBox(e).Translate(pos)

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2582,7 +2582,10 @@ func (p *Player) checkBlockCollisions(vel mgl64.Vec3) {
 	entityBBox := Type.BBox(p).Translate(p.Position())
 	deltaX, deltaY, deltaZ := vel[0], vel[1], vel[2]
 
-	p.checkEntityInsiders(entityBBox)
+	//It is already checked if MovementComputer is used
+	if p.session() != session.Nop {
+		p.checkEntityInsiders(entityBBox)
+	}
 
 	grown := entityBBox.Extend(vel).Grow(0.25)
 	low, high := grown.Min(), grown.Max()


### PR DESCRIPTION
I think this should be called for all moving entities