### PR TITLE
session/player.go: send UI inventory to keep it in-sync

### DIFF
--- a/server/session/player.go
+++ b/server/session/player.go
@@ -657,7 +657,6 @@ func (s *Session) uiInventoryFunc(tx *world.Tx, c Controllable) inventory.SlotFu
 		}
 		s.sendInv(s.ui, protocol.WindowIDUI)
 	}
-	
 }
 
 // SendHeldSlot sends the currently held hotbar slot.

--- a/server/session/player.go
+++ b/server/session/player.go
@@ -655,7 +655,9 @@ func (s *Session) uiInventoryFunc(tx *world.Tx, c Controllable) inventory.SlotFu
 				s.sendEnchantmentOptions(tx, c, pos, after)
 			}
 		}
+		s.sendInv(s.ui, protocol.WindowIDUI)
 	}
+	
 }
 
 // SendHeldSlot sends the currently held hotbar slot.


### PR DESCRIPTION
it is necessary that in any case the player receives a content update in the UI inventory! if, ex. cancel the dropping of an item when the inventory is full, the phantom item will remain before the client rejoin