### PR TITLE
Add count option to EnchantedHitAction and CriticalHitAction.

### DIFF
--- a/server/entity/action.go
+++ b/server/entity/action.go
@@ -14,11 +14,19 @@ type HurtAction struct{ action }
 
 // CriticalHitAction is a world.EntityAction that makes an entity display critical hit particles. This will show stars
 // around the entity.
-type CriticalHitAction struct{ action }
+type CriticalHitAction struct {
+	action
+	// Count is the count of particles around the entity.
+	Count int
+}
 
 // EnchantedHitAction is a world.Action that makes an entity display enchanted hit particles. This will show circles
 // around the entity.
-type EnchantedHitAction struct{ action }
+type EnchantedHitAction struct {
+	action
+	// Count is the count of particles around the entity.
+	Count int
+}
 
 // DeathAction is a world.EntityAction that makes an entity display the death animation. After this animation, the
 // entity disappears from viewers watching it.

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -973,16 +973,22 @@ func (s *Session) ViewEntityAction(e world.Entity, a world.EntityAction) {
 			EventType:       packet.ActorEventHurt,
 		})
 	case entity.CriticalHitAction:
+		if act.Count == 0 {
+			act.Count = 55
+		}
 		s.writePacket(&packet.Animate{
 			ActionType:      packet.AnimateActionCriticalHit,
 			EntityRuntimeID: s.entityRuntimeID(e),
-			Data:            55,
+			Data:            float32(act.Count),
 		})
 	case entity.EnchantedHitAction:
+		if act.Count == 0 {
+			act.Count = 15
+		}
 		s.writePacket(&packet.Animate{
 			ActionType:      packet.AnimateActionMagicCriticalHit,
 			EntityRuntimeID: s.entityRuntimeID(e),
-			Data:            15,
+			Data:            float32(act.Count),
 		})
 	case entity.DeathAction:
 		s.writePacket(&packet.ActorEvent{

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -973,7 +973,7 @@ func (s *Session) ViewEntityAction(e world.Entity, a world.EntityAction) {
 			EventType:       packet.ActorEventHurt,
 		})
 	case entity.CriticalHitAction:
-		if act.Count == 0 {
+		if act.Count <= 0 {
 			act.Count = 55
 		}
 		s.writePacket(&packet.Animate{
@@ -982,7 +982,7 @@ func (s *Session) ViewEntityAction(e world.Entity, a world.EntityAction) {
 			Data:            float32(act.Count),
 		})
 	case entity.EnchantedHitAction:
-		if act.Count == 0 {
+		if act.Count <= 0 {
 			act.Count = 15
 		}
 		s.writePacket(&packet.Animate{


### PR DESCRIPTION
answer to the question right away: zero check on these animations should be because the appear of corresponding particles is the reason why we're playing these entity actions