### PR TITLE
server/player: Implement cross-world transfer support

### DIFF
--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -173,7 +173,7 @@ func (NopHandler) HandleMove(*Context, mgl64.Vec3, cube.Rotation)               
 func (NopHandler) HandleJump(*Player)                                                      {}
 func (NopHandler) HandleTeleport(*Context, mgl64.Vec3)                                     {}
 func (NopHandler) HandleChangeWorld(*Player, *world.World, *world.World)                   {}
-func (NopHandler) HandleWorldTransfer(*Context, **world.World, *mgl64.Vec3)                 {}
+func (NopHandler) HandleWorldTransfer(*Context, **world.World, *mgl64.Vec3)                {}
 func (NopHandler) HandleToggleSprint(*Context, bool)                                       {}
 func (NopHandler) HandleToggleSneak(*Context, bool)                                        {}
 func (NopHandler) HandleCommandExecution(*Context, cmd.Command, []string)                  {}

--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -28,6 +28,10 @@ type Handler interface {
 	HandleTeleport(ctx *Context, pos mgl64.Vec3)
 	// HandleChangeWorld handles when the player is added to a new world. before may be nil.
 	HandleChangeWorld(p *Player, before, after *world.World)
+	// HandleWorldTransfer handles a player being transferred to a different world via TransferToWorld.
+	// ctx.Cancel() may be called to cancel the transfer. The destination world and position may be
+	// changed by assigning to *w and *pos.
+	HandleWorldTransfer(ctx *Context, w **world.World, pos *mgl64.Vec3)
 	// HandleToggleSprint handles when the player starts or stops sprinting.
 	// After is true if the player is sprinting after toggling (changing their sprinting state).
 	HandleToggleSprint(ctx *Context, after bool)
@@ -169,6 +173,7 @@ func (NopHandler) HandleMove(*Context, mgl64.Vec3, cube.Rotation)               
 func (NopHandler) HandleJump(*Player)                                                      {}
 func (NopHandler) HandleTeleport(*Context, mgl64.Vec3)                                     {}
 func (NopHandler) HandleChangeWorld(*Player, *world.World, *world.World)                   {}
+func (NopHandler) HandleWorldTransfer(*Context, **world.World, *mgl64.Vec3)                 {}
 func (NopHandler) HandleToggleSprint(*Context, bool)                                       {}
 func (NopHandler) HandleToggleSneak(*Context, bool)                                        {}
 func (NopHandler) HandleCommandExecution(*Context, cmd.Command, []string)                  {}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2183,6 +2183,10 @@ func (p *Player) TransferToWorld(w *world.World, pos mgl64.Vec3) *world.EntityHa
 	p.ResetFallDistance()
 
 	handle := p.tx.RemoveEntity(p)
+	if handle == nil {
+		// The player was already removed from its world (e.g. a previous transfer this tick).
+		return p.handle
+	}
 	w.Exec(func(tx *world.Tx) {
 		np := tx.AddEntity(handle).(*Player)
 		np.Teleport(pos)

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2161,6 +2161,37 @@ func (p *Player) PickBlock(pos cube.Pos) {
 	p.SetHeldItems(pickedItem, offhand)
 }
 
+// TransferToWorld transfers the player to a different world, teleporting them to the position
+// passed. If the destination world is the same as the player's current one, the call behaves
+// like Teleport. ctx.Cancel() may be used in HandleWorldTransfer to cancel the transfer.
+// Calling TransferToWorld may lead to the player being removed from its world and being added
+// to a new world. This means that p cannot be assumed to be valid after a call to TransferToWorld.
+func (p *Player) TransferToWorld(w *world.World, pos mgl64.Vec3) *world.EntityHandle {
+	if w == p.tx.World() {
+		p.Teleport(pos)
+		return p.handle
+	}
+	ctx := event.C(p)
+	if p.Handler().HandleWorldTransfer(ctx, &w, &pos); ctx.Cancelled() {
+		return p.handle
+	}
+	if w == p.tx.World() {
+		p.Teleport(pos)
+		return p.handle
+	}
+
+	p.ResetFallDistance()
+
+	handle := p.tx.RemoveEntity(p)
+	w.Exec(func(tx *world.Tx) {
+		np := tx.AddEntity(handle).(*Player)
+		np.Teleport(pos)
+		np.session().SendRespawn(pos, np)
+		np.SetVisible()
+	})
+	return p.handle
+}
+
 // Teleport teleports the player to a target position in the world. Unlike Move, it immediately changes the
 // position of the player, rather than showing an animation.
 func (p *Player) Teleport(pos mgl64.Vec3) {

--- a/server/world/tx.go
+++ b/server/world/tx.go
@@ -206,6 +206,19 @@ func (tx *Tx) RemoveEntity(e Entity) *EntityHandle {
 	return tx.World().removeEntity(e, tx)
 }
 
+// TransferEntity removes the Entity from the World tied to this Tx and re-adds
+// it to the World passed at the position passed. The destination World may be
+// the same as the current one, in which case this acts like a teleport
+// scheduled via World.Exec. After transferring the Entity from the World, the
+// Entity is no longer usable.
+func (tx *Tx) TransferEntity(e Entity, w *World, pos mgl64.Vec3) {
+	handle := tx.RemoveEntity(e)
+	handle.data.Pos = pos
+	w.Exec(func(tx *Tx) {
+		tx.AddEntity(handle)
+	})
+}
+
 // EntitiesWithin returns an iterator that yields all entities contained within
 // the cube.BBox passed.
 func (tx *Tx) EntitiesWithin(box cube.BBox) iter.Seq[Entity] {

--- a/server/world/tx.go
+++ b/server/world/tx.go
@@ -213,6 +213,9 @@ func (tx *Tx) RemoveEntity(e Entity) *EntityHandle {
 // Entity is no longer usable.
 func (tx *Tx) TransferEntity(e Entity, w *World, pos mgl64.Vec3) {
 	handle := tx.RemoveEntity(e)
+	if handle == nil {
+		return
+	}
 	handle.data.Pos = pos
 	w.Exec(func(tx *Tx) {
 		tx.AddEntity(handle)


### PR DESCRIPTION
Added `Player.TransferToWorld` and `Tx.TransferEntity` for moving entities between worlds, and a cancellable `HandleWorldTransfer` event. This will be required to implement portal functionality.