### PR TITLE
server/session: Fix debug drawer deadlock by queueing mutations

### DIFF
--- a/server/player/debug/shape.go
+++ b/server/player/debug/shape.go
@@ -28,12 +28,8 @@ func (s *shape) ShapeID() int {
 	if id := s.id.Load(); id != 0 {
 		return int(id)
 	}
-
-	id := nextShapeID.Add(1)
-	if !s.id.CompareAndSwap(0, id) {
-		id = s.id.Load()
-	}
-	return int(id)
+	s.id.CompareAndSwap(0, nextShapeID.Add(1))
+	return int(s.id.Load())
 }
 
 // Arrow represents an arrow shape that can be drawn at any point in the world. It has a head which can also

--- a/server/player/debug/shape.go
+++ b/server/player/debug/shape.go
@@ -20,16 +20,20 @@ type Shape interface {
 // shape is a base type for all shapes that implements the Shape interface. It contains a unique identifier
 // that is lazily initialised when the ShapeID method is called for the first time.
 type shape struct {
-	id *int
+	id atomic.Int32
 }
 
 // ShapeID ...
 func (s *shape) ShapeID() int {
-	if s.id == nil {
-		id := int(nextShapeID.Add(1))
-		s.id = &id
+	if id := s.id.Load(); id != 0 {
+		return int(id)
 	}
-	return *s.id
+
+	id := nextShapeID.Add(1)
+	if !s.id.CompareAndSwap(0, id) {
+		id = s.id.Load()
+	}
+	return int(id)
 }
 
 // Arrow represents an arrow shape that can be drawn at any point in the world. It has a head which can also

--- a/server/session/player.go
+++ b/server/session/player.go
@@ -842,17 +842,18 @@ func (s *Session) SendHudUpdates() {
 // AddDebugShape adds a debug shape to be rendered to the player. If the shape already exists, it will be
 // updated with the new information.
 func (s *Session) AddDebugShape(shape debug.Shape) {
-	s.debugShapesAdd <- shape
+	if s == Nop {
+		return
+	}
+	s.queueDebugShapeUpdate(debugShapeUpdate{id: shape.ShapeID(), shape: shape})
 }
 
 // RemoveDebugShape removes a debug shape from the player by its unique identifier.
 func (s *Session) RemoveDebugShape(shape debug.Shape) {
-	s.debugShapesMu.RLock()
-	defer s.debugShapesMu.RUnlock()
-
-	if _, ok := s.debugShapes[shape.ShapeID()]; ok {
-		s.debugShapesRemove <- shape.ShapeID()
+	if s == Nop {
+		return
 	}
+	s.queueDebugShapeUpdate(debugShapeUpdate{id: shape.ShapeID()})
 }
 
 // VisibleDebugShapes returns a slice of all debug shapes that are currently being shown to the player.
@@ -866,12 +867,15 @@ func (s *Session) VisibleDebugShapes() []debug.Shape {
 // RemoveAllDebugShapes removes all rendered debug shapes from the player, as well as any shapes that have
 // not yet been rendered.
 func (s *Session) RemoveAllDebugShapes() {
+	if s == Nop {
+		return
+	}
 	s.debugShapesMu.Lock()
 	defer s.debugShapesMu.Unlock()
 
-	s.debugShapesAdd = make(chan debug.Shape, 256)
+	s.debugShapeUpdates = s.debugShapeUpdates[:0]
 	for id := range s.debugShapes {
-		s.debugShapesRemove <- id
+		s.debugShapeUpdates = append(s.debugShapeUpdates, debugShapeUpdate{id: id})
 	}
 }
 
@@ -879,27 +883,37 @@ func (s *Session) RemoveAllDebugShapes() {
 // every tick to allow for batching and time-efficient updates.
 func (s *Session) SendDebugShapes(dim world.Dimension) {
 	s.debugShapesMu.Lock()
-	defer s.debugShapesMu.Unlock()
-
-	if len(s.debugShapesAdd) == 0 && len(s.debugShapesRemove) == 0 {
+	updates := s.debugShapeUpdates
+	if len(updates) == 0 {
+		s.debugShapesMu.Unlock()
 		return
 	}
 
-	shapes := make([]protocol.DebugDrawerShape, 0, len(s.debugShapesAdd)+len(s.debugShapesRemove))
-loop:
-	for {
-		select {
-		case shape := <-s.debugShapesAdd:
-			s.debugShapes[shape.ShapeID()] = shape
-			shapes = append(shapes, debugShapeToProtocol(shape, dim, s.shapeAttachedEntityRuntimeID(shape)))
-		case id := <-s.debugShapesRemove:
-			delete(s.debugShapes, id)
-			shapes = append(shapes, protocol.DebugDrawerShape{NetworkID: uint64(id), DimensionID: protocol.Option(s.dimensionID(dim)), ExtraShapeData: &protocol.LastShape{}})
-		default:
-			break loop
+	shapes := make([]protocol.DebugDrawerShape, 0, len(updates))
+	for _, update := range updates {
+		if update.shape == nil {
+			delete(s.debugShapes, update.id)
+			shapes = append(shapes, protocol.DebugDrawerShape{
+				NetworkID:      uint64(update.id),
+				DimensionID:    protocol.Option(s.dimensionID(dim)),
+				ExtraShapeData: &protocol.LastShape{},
+			})
+			continue
 		}
+		s.debugShapes[update.id] = update.shape
+		shapes = append(shapes, debugShapeToProtocol(update.shape, dim, s.shapeAttachedEntityRuntimeID(update.shape)))
 	}
+	s.debugShapeUpdates = s.debugShapeUpdates[:0]
+	s.debugShapesMu.Unlock()
+
 	s.writePacket(&packet.DebugDrawer{Shapes: shapes})
+}
+
+// queueDebugShapeUpdate queues a debug shape mutation to be applied the next time debug shapes are sent.
+func (s *Session) queueDebugShapeUpdate(update debugShapeUpdate) {
+	s.debugShapesMu.Lock()
+	defer s.debugShapesMu.Unlock()
+	s.debugShapeUpdates = append(s.debugShapeUpdates, update)
 }
 
 // valueOrDefault returns the value passed if it is not the zero value of the type T, otherwise it returns

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -97,10 +97,16 @@ type Session struct {
 
 	debugShapesMu     sync.RWMutex
 	debugShapes       map[int]debug.Shape
-	debugShapesAdd    chan debug.Shape
-	debugShapesRemove chan int
+	debugShapeUpdates []debugShapeUpdate
 
 	closeBackground chan struct{}
+}
+
+// debugShapeUpdate represents a pending debug shape mutation. If shape is nil, the update removes the
+// debug shape with the matching ID. Updates are applied in order when the session sends debug shapes.
+type debugShapeUpdate struct {
+	id    int
+	shape debug.Shape
 }
 
 // Conn represents a connection that packets are read from and written to by a Session. In addition, it holds some
@@ -187,8 +193,7 @@ func (conf Config) New(conn Conn) *Session {
 		hudUpdates:             make(map[hud.Element]bool),
 		hiddenHud:              make(map[hud.Element]struct{}),
 		debugShapes:            make(map[int]debug.Shape),
-		debugShapesAdd:         make(chan debug.Shape, 256),
-		debugShapesRemove:      make(chan int, 256),
+		debugShapeUpdates:      make([]debugShapeUpdate, 0, 256),
 	}
 	s.openedWindow.Store(inventory.New(1, nil))
 	s.openedPos.Store(&cube.Pos{})


### PR DESCRIPTION
  ## Summary

  Fixes a debug drawer deadlock/blocking hazard by replacing the separate bounded add/remove channels with an ordered pending mutation queue.

  ## Why

  The old debug shape path used:

  - `debugShapesAdd chan debug.Shape`
  - `debugShapesRemove chan int`

  Those channels were bounded. If either filled, callers could block while adding/removing debug shapes. The more dangerous case was `RemoveDebugShape`: it held `debugShapesMu.RLock()` while sending to `debugShapesRemove`. If that send blocked, `SendDebugShapes` could not acquire the write lock needed to drain pending removals.

  The two-channel design also meant add/remove ordering was not guaranteed during drain.

  ## What changed

  - Replaced the two bounded channels with `[]debugShapeUpdate`.
  - Queued add/remove mutations under `debugShapesMu`.
  - Applied queued mutations in order from `SendDebugShapes`.
  - Released `debugShapesMu` before writing the packet.
  - Made debug shape ID initialization atomic instead of `*int` lazy initialization.
