### PR TITLE
block/model: Allign connected barrier collision with vanilla

### DIFF
--- a/server/block/model/fence.go
+++ b/server/block/model/fence.go
@@ -13,27 +13,63 @@ type Fence struct {
 	Wood bool
 }
 
+const (
+	fenceHeight = 1.5
+	fenceInset  = 0.375
+)
+
 // BBox returns multiple physics.BBox depending on how many connections it has with the surrounding blocks.
 func (f Fence) BBox(pos cube.Pos, s world.BlockSource) []cube.BBox {
-	const offset = 0.375
+	boxes := make([]cube.BBox, 0, 2)
 
-	boxes := make([]cube.BBox, 0, 5)
-	mainBox := cube.Box(offset, 0, offset, 1-offset, 1.5, 1-offset)
+	connectWest, connectEast := f.checkConnection(pos, cube.FaceWest, s), f.checkConnection(pos, cube.FaceEast, s)
+	connectNorth, connectSouth := f.checkConnection(pos, cube.FaceNorth, s), f.checkConnection(pos, cube.FaceSouth, s)
 
-	for i := cube.Face(2); i < 6; i++ {
-		pos := pos.Side(i)
-		block := s.Block(pos)
-
-		if fence, ok := block.Model().(Fence); (ok && fence.Wood == f.Wood) || block.Model().FaceSolid(pos, i, s) {
-			boxes = append(boxes, mainBox.ExtendTowards(i, offset))
-		} else if _, ok := block.Model().(FenceGate); ok {
-			boxes = append(boxes, mainBox.ExtendTowards(i, offset))
+	// Check if we have any connections on the Z axis
+	if connectWest || connectEast {
+		sideBox := cube.Box(0, 0, 0, 1, fenceHeight, 1).Stretch(cube.Z, -fenceInset)
+		if connectWest {
+			boxes = append(boxes, sideBox.ExtendTowards(cube.FaceEast, -fenceInset))
+		}
+		if connectEast {
+			boxes = append(boxes, sideBox.ExtendTowards(cube.FaceWest, -fenceInset))
 		}
 	}
-	return append(boxes, mainBox)
+
+	// Check if we have any connections on the X axis
+	if connectNorth || connectSouth {
+		sideBox := cube.Box(0, 0, 0, 1, fenceHeight, 1).Stretch(cube.X, -fenceInset)
+		if connectNorth {
+			boxes = append(boxes, sideBox.ExtendTowards(cube.FaceSouth, -fenceInset))
+		}
+		if connectSouth {
+			boxes = append(boxes, sideBox.ExtendTowards(cube.FaceNorth, -fenceInset))
+		}
+	}
+
+	// If no connections, create a center post box
+	if len(boxes) == 0 {
+		boxes = append(boxes, cube.Box(fenceInset, 0, fenceInset, 1-fenceInset, fenceHeight, 1-fenceInset))
+	}
+
+	return boxes
 }
 
 // FaceSolid returns true if the face is cube.FaceDown or cube.FaceUp.
 func (f Fence) FaceSolid(_ cube.Pos, face cube.Face, _ world.BlockSource) bool {
 	return face == cube.FaceDown || face == cube.FaceUp
+}
+
+// checkConnection checks if the block at the given position and face has a connection to the current fence block.
+func (f Fence) checkConnection(pos cube.Pos, face cube.Face, src world.BlockSource) bool {
+	sidePos := pos.Side(face)
+	sideBlock := src.Block(sidePos)
+	if fence, ok := sideBlock.Model().(Fence); ok && fence.Wood == f.Wood {
+		return true
+	}
+	if sideBlock.Model().FaceSolid(sidePos, face.Opposite(), src) {
+		return true
+	}
+	_, ok := sideBlock.Model().(FenceGate)
+	return ok
 }

--- a/server/block/model/thin.go
+++ b/server/block/model/thin.go
@@ -9,28 +9,58 @@ import (
 // on solid faces next to it.
 type Thin struct{}
 
+const (
+	thinHeight = 1
+	thinInset  = 7.0 / 16.0
+)
+
 // BBox returns a slice of physics.BBox that depends on the blocks surrounding the Thin block. Thin blocks can connect
 // to any other Thin block, wall or solid faces of other blocks.
 func (t Thin) BBox(pos cube.Pos, s world.BlockSource) []cube.BBox {
-	const offset = 0.4375
+	boxes := make([]cube.BBox, 0, 2)
 
-	boxes := make([]cube.BBox, 0, 5)
-	mainBox := cube.Box(offset, 0, offset, 1-offset, 1, 1-offset)
-
-	for _, f := range cube.HorizontalFaces() {
-		pos := pos.Side(f)
-		block := s.Block(pos)
-
-		_, thin := block.Model().(Thin)
-		_, wall := block.Model().(Wall)
-		if thin || wall || block.Model().FaceSolid(pos, f.Opposite(), s) {
-			boxes = append(boxes, mainBox.ExtendTowards(f, offset))
+	// Check if we have any connections on the Z axis
+	connectWest, connectEast := t.checkConnection(pos, cube.FaceWest, s), t.checkConnection(pos, cube.FaceEast, s)
+	if connectWest || connectEast {
+		box := cube.Box(0, 0, 0, 1, thinHeight, 1).Stretch(cube.Z, -thinInset)
+		if !connectWest {
+			box = box.ExtendTowards(cube.FaceWest, -thinInset)
+		} else if !connectEast {
+			box = box.ExtendTowards(cube.FaceEast, -thinInset)
 		}
+		boxes = append(boxes, box)
 	}
-	return append(boxes, mainBox)
+
+	// Check if we have any connections on the X axis
+	connectNorth, connectSouth := t.checkConnection(pos, cube.FaceNorth, s), t.checkConnection(pos, cube.FaceSouth, s)
+	if connectNorth || connectSouth {
+		box := cube.Box(0, 0, 0, 1, thinHeight, 1).Stretch(cube.X, -thinInset)
+		if !connectNorth {
+			box = box.ExtendTowards(cube.FaceNorth, -thinInset)
+		} else if !connectSouth {
+			box = box.ExtendTowards(cube.FaceSouth, -thinInset)
+		}
+		boxes = append(boxes, box)
+	}
+
+	// If no connections, create a center post box
+	if len(boxes) == 0 {
+		boxes = append(boxes, cube.Box(0, 0, 0, 1, thinHeight, 1).Stretch(cube.X, -thinInset).Stretch(cube.Z, -thinInset))
+	}
+
+	return boxes
 }
 
 // FaceSolid returns true if the face passed is cube.FaceDown.
 func (t Thin) FaceSolid(_ cube.Pos, face cube.Face, _ world.BlockSource) bool {
 	return face == cube.FaceDown
+}
+
+// checkConnection checks if the block at the given position and face has a connection to the current thin block.
+func (t Thin) checkConnection(pos cube.Pos, face cube.Face, s world.BlockSource) bool {
+	sidePos := pos.Side(face)
+	sideBlock := s.Block(sidePos)
+	_, isThin := sideBlock.Model().(Thin)
+	_, isWall := sideBlock.Model().(Wall)
+	return isThin || isWall || sideBlock.Model().FaceSolid(sidePos, face.Opposite(), s)
 }


### PR DESCRIPTION
## Summary

Update fence and thin block collision models to match vanilla Minecraft behavior:

- **Fence collision**: Use connected axis-aligned boxes instead of a center post with independent side extensions.
- **Thin block collision** (glass panes, iron bars): Use pane-shaped connected axis boxes.
- **Solid neighbor checks**: Query the neighboring block's face pointing back toward the current block (using `face.Opposite()`).

## Rationale

**Fences** are 1.5 blocks tall with directional connections extending from a center post. They connect to the solid _back_ sides of stairs—which means the connection test must inspect the neighbor's inward-facing face (`face.Opposite()`), not the outward face.

**Glass panes and iron bars** use a 2×2 pixel shape (2/16 width) when unconnected, with collision matching the visual pane shape. Like fences, they connect to the solid back sides of stairs.

**References**
- Fences: https://minecraft.wiki/w/Fence, https://minecraft.wiki/w/Fence#Block_states
- Glass panes: https://minecraft.wiki/w/Glass_Pane, https://minecraft.wiki/w/Glass_Pane#Block_states
- Iron bars: https://minecraft.wiki/w/Iron_Bars