### PR TITLE
world: Implement async chunk load/generation preparation

### DIFF
--- a/server/session/chunk_interaction.go
+++ b/server/session/chunk_interaction.go
@@ -1,0 +1,24 @@
+package session
+
+import (
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/go-gl/mathgl/mgl64"
+)
+
+// chunkInteractionReady reports if the block position is in a chunk that was
+// already sent to this session. Client-driven block actions must pass this check
+// before touching world state that may otherwise synchronously load a chunk.
+func (s *Session) chunkInteractionReady(pos cube.Pos) bool {
+	return s.chunkPosInteractionReady(world.ChunkPos{int32(pos[0] >> 4), int32(pos[2] >> 4)})
+}
+
+// positionInteractionReady reports if an entity/player position is in a chunk
+// this session can safely interact with.
+func (s *Session) positionInteractionReady(pos mgl64.Vec3) bool {
+	return s.chunkPosInteractionReady(world.ChunkPos{int32(pos[0]) >> 4, int32(pos[2]) >> 4})
+}
+
+func (s *Session) chunkPosInteractionReady(pos world.ChunkPos) bool {
+	return s.chunkLoader.Loaded(pos)
+}

--- a/server/session/handler_block_actor_data.go
+++ b/server/session/handler_block_actor_data.go
@@ -24,6 +24,9 @@ func (b BlockActorDataHandler) Handle(p packet.Packet, s *Session, tx *world.Tx,
 		if !canReach(c, pos.Vec3Middle()) {
 			return fmt.Errorf("block at %v is not within reach", pos)
 		}
+		if !s.chunkInteractionReady(pos) {
+			return nil
+		}
 		if id == "Sign" {
 			return b.handleSign(pk, pos, s, tx, c)
 		}

--- a/server/session/handler_block_pick_request.go
+++ b/server/session/handler_block_pick_request.go
@@ -10,8 +10,12 @@ import (
 type BlockPickRequestHandler struct{}
 
 // Handle ...
-func (b BlockPickRequestHandler) Handle(p packet.Packet, _ *Session, _ *world.Tx, c Controllable) error {
+func (b BlockPickRequestHandler) Handle(p packet.Packet, s *Session, _ *world.Tx, c Controllable) error {
 	pk := p.(*packet.BlockPickRequest)
-	c.PickBlock(cube.Pos{int(pk.Position.X()), int(pk.Position.Y()), int(pk.Position.Z())})
+	pos := cube.Pos{int(pk.Position.X()), int(pk.Position.Y()), int(pk.Position.Z())}
+	if !s.chunkInteractionReady(pos) {
+		return nil
+	}
+	c.PickBlock(pos)
 	return nil
 }

--- a/server/session/handler_inventory_transaction.go
+++ b/server/session/handler_inventory_transaction.go
@@ -70,7 +70,7 @@ func (h *InventoryTransactionHandler) Handle(p packet.Packet, s *Session, tx *wo
 		if err = s.VerifyAndSetHeldSlot(int(data.HotBarSlot), stackToItem(s.br, data.HeldItem.Stack), c); err != nil {
 			return
 		}
-		return h.handleReleaseItemTransaction(c)
+		return h.handleReleaseItemTransaction(s, c)
 	}
 	return fmt.Errorf("unhandled inventory transaction type %T", pk.TransactionData)
 }
@@ -137,6 +137,9 @@ func (h *InventoryTransactionHandler) handleNormalTransaction(pk *packet.Invento
 
 // handleUseItemOnEntityTransaction ...
 func (h *InventoryTransactionHandler) handleUseItemOnEntityTransaction(data *protocol.UseItemOnEntityTransactionData, s *Session, tx *world.Tx, c Controllable) error {
+	if !s.positionInteractionReady(c.Position()) {
+		return nil
+	}
 	s.swingingArm.Store(true)
 	defer s.swingingArm.Store(false)
 
@@ -154,6 +157,9 @@ func (h *InventoryTransactionHandler) handleUseItemOnEntityTransaction(data *pro
 	e, ok := handle.Entity(tx)
 	if !ok {
 		s.conf.Log.Debug("invalid entity interaction: entity is not in the same world (anymore)", "ID", data.TargetEntityRuntimeID)
+		return nil
+	}
+	if !s.positionInteractionReady(e.Position()) {
 		return nil
 	}
 	var valid bool
@@ -187,10 +193,20 @@ func (h *InventoryTransactionHandler) handleUseItemTransaction(data *protocol.Us
 
 	switch data.ActionType {
 	case protocol.UseItemActionBreakBlock:
+		if !s.chunkInteractionReady(pos) {
+			return nil
+		}
 		c.BreakBlock(pos)
 	case protocol.UseItemActionClickBlock:
-		c.UseItemOnBlock(pos, cube.Face(data.BlockFace), vec32To64(data.ClickedPosition))
+		face := cube.Face(data.BlockFace)
+		if !s.chunkInteractionReady(pos) || !s.chunkInteractionReady(pos.Side(face)) {
+			return nil
+		}
+		c.UseItemOnBlock(pos, face, vec32To64(data.ClickedPosition))
 	case protocol.UseItemActionClickAir:
+		if !s.positionInteractionReady(c.Position()) {
+			return nil
+		}
 		c.UseItem()
 	default:
 		return fmt.Errorf("unhandled UseItem ActionType %v", data.ActionType)
@@ -199,7 +215,10 @@ func (h *InventoryTransactionHandler) handleUseItemTransaction(data *protocol.Us
 }
 
 // handleReleaseItemTransaction ...
-func (h *InventoryTransactionHandler) handleReleaseItemTransaction(c Controllable) error {
+func (h *InventoryTransactionHandler) handleReleaseItemTransaction(s *Session, c Controllable) error {
+	if !s.positionInteractionReady(c.Position()) {
+		return nil
+	}
 	c.ReleaseItem()
 	return nil
 }

--- a/server/session/handler_item_stack_request.go
+++ b/server/session/handler_item_stack_request.go
@@ -88,8 +88,12 @@ func (h *ItemStackRequestHandler) handleRequest(req protocol.ItemStackRequest, s
 			err = h.handleBeaconPayment(a, s, tx)
 		case *protocol.CraftRecipeStackRequestAction:
 			if s.containerOpened.Load() {
+				openedPos := *s.openedPos.Load()
+				if !s.chunkInteractionReady(openedPos) {
+					return nil
+				}
 				var special bool
-				switch tx.Block(*s.openedPos.Load()).(type) {
+				switch tx.Block(openedPos).(type) {
 				case block.SmithingTable:
 					err, special = h.handleSmithing(a, s, tx), true
 				case block.Stonecutter:
@@ -207,7 +211,11 @@ func (h *ItemStackRequestHandler) handleSwap(a *protocol.SwapStackRequestAction,
 // smelting. If it does, it will drop the rewards at the player's location.
 func (h *ItemStackRequestHandler) collectRewards(s *Session, inv *inventory.Inventory, slot int, tx *world.Tx, c Controllable) {
 	if inv == s.openedWindow.Load() && s.containerOpened.Load() && slot == inv.Size()-1 {
-		if f, ok := tx.Block(*s.openedPos.Load()).(smelter); ok {
+		openedPos := *s.openedPos.Load()
+		if !s.chunkInteractionReady(openedPos) {
+			return
+		}
+		if f, ok := tx.Block(openedPos).(smelter); ok {
 			for _, o := range entity.NewExperienceOrbs(entity.EyePosition(c), f.ResetExperience()) {
 				tx.AddEntity(o)
 			}

--- a/server/session/handler_player_action.go
+++ b/server/session/handler_player_action.go
@@ -34,12 +34,18 @@ func handlePlayerAction(action int32, face int32, pos protocol.BlockPos, entityR
 		defer s.swingingArm.Store(false)
 
 		s.breakingPos = cube.Pos{int(pos[0]), int(pos[1]), int(pos[2])}
+		if !s.chunkInteractionReady(s.breakingPos) {
+			return nil
+		}
 		c.StartBreaking(s.breakingPos, cube.Face(face))
 	case protocol.PlayerActionAbortBreak:
 		c.AbortBreaking()
 	case protocol.PlayerActionPredictDestroyBlock, protocol.PlayerActionStopBreak:
 		s.swingingArm.Store(true)
 		defer s.swingingArm.Store(false)
+		if !s.chunkInteractionReady(s.breakingPos) {
+			return nil
+		}
 		c.FinishBreaking()
 	case protocol.PlayerActionCrackBreak:
 		// Don't do anything for this action. It is no longer used. Block

--- a/server/session/handler_player_auth_input.go
+++ b/server/session/handler_player_auth_input.go
@@ -45,6 +45,9 @@ func (h PlayerAuthInputHandler) handleMovement(pk *packet.PlayerAuthInput, s *Se
 	pk.Position = pk.Position.Sub(mgl32.Vec3{0, 1.62}) // Sub the base offset of players from the pos.
 
 	newPos := vec32To64(pk.Position)
+	if !s.positionInteractionReady(pos) || !s.positionInteractionReady(newPos) {
+		return nil
+	}
 	deltaPos, deltaYaw, deltaPitch := newPos.Sub(pos), float64(pk.Yaw)-yaw, float64(pk.Pitch)-pitch
 	if mgl64.FloatEqual(deltaPos.Len(), 0) && mgl64.FloatEqual(deltaYaw, 0) && mgl64.FloatEqual(deltaPitch, 0) {
 		// The PlayerAuthInput packet is sent every tick, so don't do anything if the position and rotation
@@ -164,6 +167,9 @@ func (h PlayerAuthInputHandler) handleUseItemData(data protocol.UseItemTransacti
 	// Seems like this is only used for breaking blocks at the moment.
 	switch data.ActionType {
 	case protocol.UseItemActionBreakBlock:
+		if !s.chunkInteractionReady(pos) {
+			return nil
+		}
 		c.BreakBlock(pos)
 	default:
 		return fmt.Errorf("unhandled UseItem ActionType for PlayerAuthInput packet %v", data.ActionType)

--- a/server/world/async_chunk_test.go
+++ b/server/world/async_chunk_test.go
@@ -1,0 +1,128 @@
+package world
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world/chunk"
+)
+
+type blockingProvider struct {
+	NopProvider
+	started chan struct{}
+	release chan struct{}
+	loads   atomic.Int32
+}
+
+func newBlockingProvider() *blockingProvider {
+	return &blockingProvider{started: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (p *blockingProvider) LoadColumn(ChunkPos, Dimension) (*chunk.Column, error) {
+	if p.loads.Add(1) == 1 {
+		close(p.started)
+	}
+	<-p.release
+	return &chunk.Column{Chunk: chunk.New(DefaultBlockRegistry, Overworld.Range())}, nil
+}
+
+type countingGenerator struct {
+	calls atomic.Int32
+}
+
+func (g *countingGenerator) GenerateChunk(ChunkPos, *chunk.Chunk) {
+	g.calls.Add(1)
+}
+
+func (g *countingGenerator) DefaultSpawn(Dimension) cube.Pos { return cube.Pos{} }
+
+type recordingViewer struct {
+	NopViewer
+	chunks atomic.Int32
+}
+
+func (v *recordingViewer) ViewChunk(ChunkPos, Dimension, map[cube.Pos]Block, *chunk.Chunk) {
+	v.chunks.Add(1)
+}
+
+func TestLoaderLoadRequestsMissingChunkAsynchronously(t *testing.T) {
+	provider := newBlockingProvider()
+	generator := &countingGenerator{}
+	w := Config{Provider: provider, Generator: generator}.New()
+	defer w.Close()
+
+	viewer := &recordingViewer{}
+	loader := NewLoader(2, w, viewer)
+
+	done := make(chan struct{})
+	w.Exec(func(tx *Tx) {
+		loader.Load(tx, 1)
+		close(done)
+	})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Loader.Load blocked on chunk preparation")
+	}
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("chunk preparation was not requested")
+	}
+	if viewer.chunks.Load() != 0 {
+		t.Fatal("pending chunk was sent before preparation completed")
+	}
+	if loader.Loaded(ChunkPos{}) {
+		t.Fatal("pending chunk was marked loaded")
+	}
+
+	close(provider.release)
+	assertEventually(t, time.Second, func() bool {
+		ch := w.Exec(func(tx *Tx) {
+			loader.Load(tx, 1)
+		})
+		<-ch
+		return viewer.chunks.Load() == 1 && loader.Loaded(ChunkPos{})
+	})
+}
+
+func TestLoaderLoadDeduplicatesPendingRequests(t *testing.T) {
+	provider := newBlockingProvider()
+	generator := &countingGenerator{}
+	w := Config{Provider: provider, Generator: generator}.New()
+	defer w.Close()
+
+	<-w.Exec(func(tx *Tx) {
+		if !tx.World().requestChunk(ChunkPos{}) {
+			t.Fatal("first chunk request was rejected")
+		}
+		if !tx.World().requestChunk(ChunkPos{}) {
+			t.Fatal("duplicate chunk request was rejected")
+		}
+	})
+
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("chunk preparation was not requested")
+	}
+	if got := provider.loads.Load(); got != 1 {
+		t.Fatalf("expected one provider load, got %v", got)
+	}
+	close(provider.release)
+}
+
+func assertEventually(t *testing.T, timeout time.Duration, f func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if f() {
+			return
+		}
+		time.Sleep(time.Millisecond * 10)
+	}
+	t.Fatal("condition was not met before timeout")
+}

--- a/server/world/chunk_bench_test.go
+++ b/server/world/chunk_bench_test.go
@@ -1,0 +1,105 @@
+package world
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world/chunk"
+	"github.com/df-mc/goleveldb/leveldb"
+	"github.com/go-gl/mathgl/mgl64"
+)
+
+type benchmarkProvider struct {
+	NopProvider
+	delay time.Duration
+	loads atomic.Int64
+}
+
+func (p *benchmarkProvider) LoadColumn(ChunkPos, Dimension) (*chunk.Column, error) {
+	p.loads.Add(1)
+	if p.delay > 0 {
+		time.Sleep(p.delay)
+	}
+	return nil, leveldb.ErrNotFound
+}
+
+type benchmarkGenerator struct {
+	work  int
+	calls atomic.Int64
+}
+
+func (g *benchmarkGenerator) GenerateChunk(pos ChunkPos, c *chunk.Chunk) {
+	g.calls.Add(1)
+	var v uint64 = uint64(pos[0])<<32 | uint64(uint32(pos[1]))
+	for i := 0; i < g.work; i++ {
+		v ^= v << 13
+		v ^= v >> 7
+		v ^= v << 17
+	}
+	if v == 0 {
+		c.SetBlock(0, 0, 0, 0, 0)
+	}
+}
+
+func (g *benchmarkGenerator) DefaultSpawn(Dimension) cube.Pos { return cube.Pos{} }
+
+type benchmarkViewer struct {
+	NopViewer
+	chunks atomic.Int64
+}
+
+func (v *benchmarkViewer) ViewChunk(ChunkPos, Dimension, map[cube.Pos]Block, *chunk.Chunk) {
+	v.chunks.Add(1)
+}
+
+func BenchmarkLoaderLoadSlowProviderLatency(b *testing.B) {
+	provider := &benchmarkProvider{delay: time.Millisecond}
+	w := Config{Provider: provider, Generator: &benchmarkGenerator{}}.New()
+	defer w.Close()
+
+	loader := NewLoader(2, w, &benchmarkViewer{})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pos := mgl64.Vec3{float64(i * 64), 64, 0}
+		<-w.Exec(func(tx *Tx) {
+			loader.Move(tx, pos)
+			loader.Load(tx, 1)
+		})
+	}
+}
+
+func BenchmarkLoaderChunkVisibilityThroughput(b *testing.B) {
+	provider := &benchmarkProvider{delay: time.Millisecond}
+	viewer := &benchmarkViewer{}
+	w := Config{Provider: provider, Generator: &benchmarkGenerator{}}.New()
+	defer w.Close()
+
+	loader := NewLoader(16, w, viewer)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for viewer.chunks.Load() < int64(b.N) {
+		<-w.Exec(func(tx *Tx) {
+			loader.Load(tx, 8)
+		})
+	}
+}
+
+func BenchmarkWorldExecLatencyDuringChunkLoad(b *testing.B) {
+	provider := &benchmarkProvider{delay: time.Millisecond}
+	w := Config{Provider: provider, Generator: &benchmarkGenerator{}}.New()
+	defer w.Close()
+
+	loader := NewLoader(2, w, &benchmarkViewer{})
+	<-w.Exec(func(tx *Tx) {
+		loader.Load(tx, 1)
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		<-w.Exec(func(tx *Tx) {})
+	}
+}

--- a/server/world/chunk_preparer.go
+++ b/server/world/chunk_preparer.go
@@ -43,6 +43,10 @@ type chunkPreparer struct {
 	// closed is closed after all workers have exited.
 	closed chan struct{}
 
+	// providerMu preserves the previous single-threaded Provider access contract.
+	providerMu sync.Mutex
+	// generatorMu preserves the previous single-threaded Generator access contract.
+	generatorMu sync.Mutex
 	// wg tracks active worker goroutines.
 	wg sync.WaitGroup
 }
@@ -115,7 +119,9 @@ func (p *chunkPreparer) worker() {
 // visible through World.chunks. The result must be committed on the transaction
 // goroutine before it can be used by gameplay or viewers.
 func (p *chunkPreparer) prepare(req chunkPrepareRequest) chunkPrepareResult {
+	p.providerMu.Lock()
 	column, err := p.w.conf.Provider.LoadColumn(req.pos, p.w.conf.Dim)
+	p.providerMu.Unlock()
 	if err == nil {
 		return chunkPrepareResult{pos: req.pos, token: req.token, column: column}
 	}
@@ -124,7 +130,9 @@ func (p *chunkPreparer) prepare(req chunkPrepareRequest) chunkPrepareResult {
 	}
 
 	c := chunk.New(p.w.conf.Blocks, p.w.Range())
+	p.generatorMu.Lock()
 	p.w.conf.Generator.GenerateChunk(req.pos, c)
+	p.generatorMu.Unlock()
 	return chunkPrepareResult{
 		pos:   req.pos,
 		token: req.token,

--- a/server/world/chunk_preparer.go
+++ b/server/world/chunk_preparer.go
@@ -1,0 +1,149 @@
+package world
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/df-mc/dragonfly/server/world/chunk"
+	"github.com/df-mc/goleveldb/leveldb"
+)
+
+type chunkPrepareState struct {
+	// token identifies the currently accepted prepare request for a chunk. It lets
+	// the transaction goroutine drop stale completions from older requests.
+	token uint64
+}
+
+type chunkPrepareRequest struct {
+	// pos is the chunk position to load from the provider or generate.
+	pos ChunkPos
+	// token mirrors the pending state token that must match before commit.
+	token uint64
+}
+
+type chunkPrepareResult struct {
+	// pos is the chunk position this result belongs to.
+	pos ChunkPos
+	// token is checked against pendingChunks before the result is published.
+	token uint64
+	// column is private prepared chunk data. It is nil when err is non-nil.
+	column *chunk.Column
+	// err is the provider/generator preparation error, if preparation failed.
+	err error
+}
+
+type chunkPreparer struct {
+	// w is used by workers to access immutable config and to schedule commit transactions.
+	w *World
+
+	// requests queues accepted chunk preparation jobs for worker goroutines.
+	requests chan chunkPrepareRequest
+	// closing is closed to ask workers to stop and to make new requests fail.
+	closing chan struct{}
+	// closed is closed after all workers have exited.
+	closed chan struct{}
+
+	// wg tracks active worker goroutines.
+	wg sync.WaitGroup
+}
+
+// newChunkPreparer starts a bounded worker pool used to load or generate chunks
+// outside the world transaction goroutine. Workers only prepare private chunk
+// data; publishing remains the responsibility of the world transaction loop.
+func newChunkPreparer(w *World, workers, queueSize int) *chunkPreparer {
+	p := &chunkPreparer{
+		w:        w,
+		requests: make(chan chunkPrepareRequest, queueSize),
+		closing:  make(chan struct{}),
+		closed:   make(chan struct{}),
+	}
+	for i := 0; i < workers; i++ {
+		p.wg.Add(1)
+		go p.worker()
+	}
+	go func() {
+		p.wg.Wait()
+		close(p.closed)
+	}()
+	return p
+}
+
+// request enqueues a chunk preparation job without blocking. False means the
+// worker queue is full or shutting down, so the caller should not mark the
+// chunk as pending.
+func (p *chunkPreparer) request(req chunkPrepareRequest) bool {
+	select {
+	case p.requests <- req:
+		return true
+	case <-p.closing:
+		return false
+	default:
+		return false
+	}
+}
+
+// close stops all prepare workers and waits until they have exited. Any
+// completions produced after shutdown starts are ignored.
+func (p *chunkPreparer) close() {
+	select {
+	case <-p.closing:
+		return
+	default:
+		close(p.closing)
+	}
+	<-p.closed
+}
+
+func (p *chunkPreparer) worker() {
+	defer p.wg.Done()
+	for {
+		select {
+		case req := <-p.requests:
+			p.submit(p.prepare(req))
+		default:
+			select {
+			case req := <-p.requests:
+				p.submit(p.prepare(req))
+			case <-p.closing:
+				return
+			}
+		}
+	}
+}
+
+// prepare performs the slow provider/generator work using data that is not yet
+// visible through World.chunks. The result must be committed on the transaction
+// goroutine before it can be used by gameplay or viewers.
+func (p *chunkPreparer) prepare(req chunkPrepareRequest) chunkPrepareResult {
+	column, err := p.w.conf.Provider.LoadColumn(req.pos, p.w.conf.Dim)
+	if err == nil {
+		return chunkPrepareResult{pos: req.pos, token: req.token, column: column}
+	}
+	if !errors.Is(err, leveldb.ErrNotFound) {
+		return chunkPrepareResult{pos: req.pos, token: req.token, err: err}
+	}
+
+	c := chunk.New(p.w.conf.Blocks, p.w.Range())
+	p.w.conf.Generator.GenerateChunk(req.pos, c)
+	return chunkPrepareResult{
+		pos:   req.pos,
+		token: req.token,
+		column: &chunk.Column{
+			Chunk: c,
+		},
+	}
+}
+
+// submit schedules a prepared chunk for transaction-thread publication. It
+// does not wait for the commit, which keeps workers available for more prepare
+// work.
+func (p *chunkPreparer) submit(result chunkPrepareResult) {
+	select {
+	case <-p.closing:
+		return
+	default:
+	}
+	p.w.Exec(func(tx *Tx) {
+		tx.World().commitPreparedChunk(result)
+	})
+}

--- a/server/world/conf.go
+++ b/server/world/conf.go
@@ -3,7 +3,6 @@ package world
 import (
 	"log/slog"
 	"math/rand/v2"
-	"runtime"
 	"time"
 )
 
@@ -51,8 +50,8 @@ type Config struct {
 	// altogether. This should be done using a Loader with a custom Viewer.
 	ChunkUnloadInterval time.Duration
 	// ChunkWorkers specifies how many background workers may prepare chunks for
-	// loading/generation. A value of 0 defaults to half the available logical CPUs,
-	// clamped to at least 1.
+	// loading/generation. A value of 0 defaults to 1 for provider/generator
+	// compatibility.
 	ChunkWorkers int
 	// ChunkPrepareQueueSize specifies the maximum amount of chunk prepare requests
 	// queued for background workers. A value of 0 defaults to ChunkWorkers*64.
@@ -97,7 +96,7 @@ func (conf Config) New() *World {
 		conf.ChunkUnloadInterval = time.Minute * 2
 	}
 	if conf.ChunkWorkers <= 0 {
-		conf.ChunkWorkers = max(1, runtime.GOMAXPROCS(0)/2)
+		conf.ChunkWorkers = 1
 	}
 	if conf.ChunkPrepareQueueSize <= 0 {
 		conf.ChunkPrepareQueueSize = conf.ChunkWorkers * 64

--- a/server/world/conf.go
+++ b/server/world/conf.go
@@ -3,6 +3,7 @@ package world
 import (
 	"log/slog"
 	"math/rand/v2"
+	"runtime"
 	"time"
 )
 
@@ -49,6 +50,13 @@ type Config struct {
 	// ChunkUnloadInterval should not be used to prevent chunks from unloading
 	// altogether. This should be done using a Loader with a custom Viewer.
 	ChunkUnloadInterval time.Duration
+	// ChunkWorkers specifies how many background workers may prepare chunks for
+	// loading/generation. A value of 0 defaults to half the available logical CPUs,
+	// clamped to at least 1.
+	ChunkWorkers int
+	// ChunkPrepareQueueSize specifies the maximum amount of chunk prepare requests
+	// queued for background workers. A value of 0 defaults to ChunkWorkers*64.
+	ChunkPrepareQueueSize int
 	// RandomTickSpeed specifies the rate at which blocks should be ticked in
 	// the World. By default, each sub chunk has 3 blocks randomly ticked per
 	// sub chunk, so the default value is 3. Setting this value to -1 or lower
@@ -88,6 +96,12 @@ func (conf Config) New() *World {
 	if conf.ChunkUnloadInterval <= 0 {
 		conf.ChunkUnloadInterval = time.Minute * 2
 	}
+	if conf.ChunkWorkers <= 0 {
+		conf.ChunkWorkers = max(1, runtime.GOMAXPROCS(0)/2)
+	}
+	if conf.ChunkPrepareQueueSize <= 0 {
+		conf.ChunkPrepareQueueSize = conf.ChunkWorkers * 64
+	}
 	if conf.Generator == nil {
 		conf.Generator = NopGenerator{}
 	}
@@ -122,6 +136,7 @@ func (conf Config) New() *World {
 		entities:         make(map[*EntityHandle]ChunkPos),
 		viewers:          make(map[*Loader]Viewer),
 		chunks:           make(map[ChunkPos]*Column),
+		pendingChunks:    make(map[ChunkPos]chunkPrepareState),
 		queueClosing:     make(chan struct{}),
 		closing:          make(chan struct{}),
 		queue:            make(chan transaction, 128),
@@ -131,6 +146,7 @@ func (conf Config) New() *World {
 		ra:               conf.Dim.Range(),
 		set:              s,
 	}
+	w.chunkPreparer = newChunkPreparer(w, conf.ChunkWorkers, conf.ChunkPrepareQueueSize)
 	w.weather = weather{w: w}
 	var h Handler = NopHandler{}
 	w.handler.Store(&h)

--- a/server/world/loader.go
+++ b/server/world/loader.go
@@ -91,25 +91,31 @@ func (l *Loader) Load(tx *Tx, n int) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if l.closed || l.w == nil {
+	if l.closed || l.w == nil || n <= 0 {
 		return
 	}
-	for i := 0; i < n; i++ {
-		if len(l.loadQueue) == 0 {
-			break
-		}
-
+	processed := 0
+	checked, queued := 0, len(l.loadQueue)
+	for processed < n && checked < queued {
 		pos := l.loadQueue[0]
-		c := tx.w.chunk(pos)
+		l.loadQueue = l.loadQueue[1:]
+		checked++
+
+		if _, ok := l.loaded[pos]; ok {
+			continue
+		}
+		c, ok := tx.w.chunkReady(pos)
+		if !ok {
+			_ = tx.w.requestChunk(pos)
+			l.loadQueue = append(l.loadQueue, pos)
+			processed++
+			continue
+		}
 
 		l.viewer.ViewChunk(pos, l.w.Dimension(), c.BlockEntities, c.Chunk)
 		l.w.addViewer(tx, c, l)
-
 		l.loaded[pos] = c
-
-		// Shift the first element from the load queue off so that we can take a new one during the next
-		// iteration.
-		l.loadQueue = l.loadQueue[1:]
+		processed++
 	}
 }
 
@@ -120,6 +126,14 @@ func (l *Loader) Chunk(pos ChunkPos) (*Column, bool) {
 	c, ok := l.loaded[pos]
 	l.mu.RUnlock()
 	return c, ok
+}
+
+// Loaded returns if the chunk at the position passed was sent to this loader's viewer.
+func (l *Loader) Loaded(pos ChunkPos) bool {
+	l.mu.RLock()
+	_, ok := l.loaded[pos]
+	l.mu.RUnlock()
+	return ok
 }
 
 // Close closes the loader. It unloads all chunks currently loaded for the viewer, and hides all entities that
@@ -193,7 +207,7 @@ func (l *Loader) populateLoadQueue() {
 	}
 
 	l.loadQueue = l.loadQueue[:0]
-	for i := int32(0); i < r; i++ {
+	for i := int32(0); i <= r; i++ {
 		l.loadQueue = append(l.loadQueue, queue[i]...)
 	}
 }

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -52,6 +52,13 @@ type World struct {
 	// chunks holds a cache of chunks currently loaded. These chunks are cleared
 	// from this map after some time of not being used.
 	chunks map[ChunkPos]*Column
+	// pendingChunks holds async chunk preparation jobs that have not been
+	// committed to chunks yet. It is only accessed on the transaction goroutine.
+	pendingChunks map[ChunkPos]chunkPrepareState
+	// chunkPreparer owns the background workers that load/generate private chunk data.
+	chunkPreparer *chunkPreparer
+	// chunkToken is incremented for each accepted prepare request to identify stale completions.
+	chunkToken uint64
 
 	// entities holds a map of entities currently loaded and the last ChunkPos
 	// that the Entity was in. These are tracked so that a call to RemoveEntity
@@ -1084,6 +1091,7 @@ func (w *World) close() {
 
 	close(w.closing)
 	w.running.Wait()
+	w.chunkPreparer.close()
 
 	close(w.queueClosing)
 	w.queueing.Wait()
@@ -1175,6 +1183,60 @@ func showEntity(e Entity, viewer Viewer) {
 	viewer.ViewEntity(e)
 	viewer.ViewEntityItems(e)
 	viewer.ViewEntityArmour(e)
+}
+
+// chunkReady looks up a chunk that has already been committed to the world. It
+// never loads or generates chunks, so callers can use it without blocking on
+// provider I/O or generation work.
+func (w *World) chunkReady(pos ChunkPos) (*Column, bool) {
+	c, ok := w.chunks[pos]
+	return c, ok
+}
+
+// requestChunk queues a missing chunk for asynchronous preparation. It
+// deduplicates in-flight work and only records the chunk as pending if the
+// request was accepted by the preparer.
+func (w *World) requestChunk(pos ChunkPos) bool {
+	if _, ok := w.chunks[pos]; ok {
+		return true
+	}
+	if _, ok := w.pendingChunks[pos]; ok {
+		return true
+	}
+	w.chunkToken++
+	state := chunkPrepareState{token: w.chunkToken}
+	w.pendingChunks[pos] = state
+	if !w.chunkPreparer.request(chunkPrepareRequest{pos: pos, token: state.token}) {
+		delete(w.pendingChunks, pos)
+		return false
+	}
+	return true
+}
+
+// commitPreparedChunk publishes an asynchronously prepared chunk on the world
+// transaction goroutine. Stale completions and failed preparations are dropped
+// so partially prepared chunks never become visible to readers.
+func (w *World) commitPreparedChunk(result chunkPrepareResult) {
+	state, ok := w.pendingChunks[result.pos]
+	if !ok || state.token != result.token {
+		return
+	}
+	delete(w.pendingChunks, result.pos)
+	if _, ok := w.chunks[result.pos]; ok {
+		return
+	}
+	if result.err != nil {
+		w.conf.Log.Error("load chunk: "+result.err.Error(), "X", result.pos[0], "Z", result.pos[1])
+		return
+	}
+	col := w.columnFrom(result.column, result.pos)
+	w.chunks[result.pos] = col
+	for _, e := range col.Entities {
+		w.entities[e] = result.pos
+		e.w = w
+	}
+	chunk.LightArea([]*chunk.Chunk{col.Chunk}, int(result.pos[0]), int(result.pos[1])).Fill()
+	w.calculateLight(result.pos)
 }
 
 // chunk reads a chunk from the position passed. If a chunk at that position is


### PR DESCRIPTION
## Description

World chunk loading and generation currently happen on the world transaction goroutine. When a provider or generator performs expensive work, it blocks the transaction loop and can cause visible lag for players.

This PR moves chunk load/generation preparation to background workers. Missing chunks are requested asynchronously, prepared off the transaction goroutine, and then committed back on the transaction goroutine before being published to the world.

The change is described as "preparation" because final publication is still serialized through the transaction loop. This keeps authoritative world mutation on the existing world transaction goroutine while avoiding provider/generator stalls during chunk streaming.

Provider and generator calls are internally serialized to preserve compatibility with existing implementations that do not support concurrent access.

## Changes
  - Added a background chunk preparation worker system for asynchronous provider loading and chunk generation.
  - Added pending chunk tracking to `World` to deduplicate in-flight chunk preparation requests.
  - Added token-based validation for prepared chunk results to prevent stale completions from being published.
  - Changed `Loader.Load` to request missing chunks asynchronously instead of synchronously loading/generating them.
  - Kept final chunk publication, entity attachment, and lighting on the world transaction goroutine.
  - Added per-session interaction guards so players can only interact with chunks that have already been sent to their loader.
  - Serialized `Provider` and `Generator` calls internally to preserve compatibility with existing non-concurrent implementations.
  - Added configuration options for chunk preparation workers and queue size.
  - Added tests covering asynchronous loader behavior and duplicate pending request deduplication.

## Benchmark
Benchmarks show the biggest improvement in `Loader.Load` latency under slow provider/generator workloads. In the slow provider benchmark, `Loader.Load` dropped from about 1.57ms/op to 0.154ms/op, roughly a 10x improvement, because it now queues missing chunks for background preparation instead of synchronously loading/generating them on the transaction goroutine.

This does not make chunk generation itself 10x faster. The provider/generator work is still performed, but it no longer blocks the world transaction loop. Chunk visibility throughput stayed broadly similar in the benchmark, with additional allocations from request/result scheduling and pending chunk bookkeeping.

The intended performance improvement is therefore reduced transaction blocking and better player/world responsiveness during expensive chunk loading or generation, rather than higher raw generation throughput.

<details>

#### Old Implementation
```
goos: windows
goarch: amd64
pkg: github.com/df-mc/dragonfly/server/world
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
BenchmarkLoaderLoadSlowProviderLatency-20      	     100	   1570929 ns/op	   57046 B/op	     122 allocs/op
BenchmarkLoaderLoadSlowProviderLatency-20      	     100	   1570323 ns/op	   57053 B/op	     122 allocs/op
BenchmarkLoaderLoadSlowProviderLatency-20      	     100	   1573912 ns/op	   57057 B/op	     122 allocs/op
BenchmarkLoaderLoadSlowProviderLatency-20      	     100	   1574440 ns/op	   57052 B/op	     122 allocs/op
BenchmarkLoaderLoadSlowProviderLatency-20      	     100	   1557202 ns/op	   57052 B/op	     122 allocs/op
BenchmarkLoaderChunkVisibilityThroughput-20    	     100	   1702759 ns/op	  103886 B/op	     117 allocs/op
BenchmarkLoaderChunkVisibilityThroughput-20    	     100	   1731578 ns/op	  103880 B/op	     117 allocs/op
BenchmarkLoaderChunkVisibilityThroughput-20    	     100	   1710443 ns/op	  103880 B/op	     117 allocs/op
BenchmarkLoaderChunkVisibilityThroughput-20    	     100	   1727873 ns/op	  103881 B/op	     117 allocs/op
BenchmarkLoaderChunkVisibilityThroughput-20    	     100	   1674584 ns/op	  103880 B/op	     117 allocs/op
BenchmarkWorldExecLatencyDuringChunkLoad-20    	     100	      1344 ns/op	     145 B/op	       3 allocs/op
BenchmarkWorldExecLatencyDuringChunkLoad-20    	     100	      1789 ns/op	     145 B/op	       3 allocs/op
BenchmarkWorldExecLatencyDuringChunkLoad-20    	     100	      1930 ns/op	     145 B/op	       3 allocs/op
BenchmarkWorldExecLatencyDuringChunkLoad-20    	     100	      1382 ns/op	     145 B/op	       3 allocs/op
BenchmarkWorldExecLatencyDuringChunkLoad-20    	     100	      1675 ns/op	     145 B/op	       3 allocs/op
PASS
ok  	github.com/df-mc/dragonfly/server/world	3.438s
```

#### New Implementation
```
goos: windows
goarch: amd64
pkg: github.com/df-mc/dragonfly/server/world
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
BenchmarkLoaderLoadSlowProviderLatency-20      	     100	    148815 ns/op	    5693 B/op	     115 allocs/op
BenchmarkLoaderLoadSlowProviderLatency-20      	     100	    159092 ns/op	    5698 B/op	     115 allocs/op
BenchmarkLoaderLoadSlowProviderLatency-20      	     100	    156444 ns/op	    5692 B/op	     115 allocs/op
BenchmarkLoaderLoadSlowProviderLatency-20      	     100	    150357 ns/op	    5709 B/op	     115 allocs/op
BenchmarkLoaderLoadSlowProviderLatency-20      	     100	    153958 ns/op	    5686 B/op	     115 allocs/op
BenchmarkLoaderChunkVisibilityThroughput-20    	     100	   1267188 ns/op	  654572 B/op	     790 allocs/op
BenchmarkLoaderChunkVisibilityThroughput-20    	     100	   1281952 ns/op	  654683 B/op	     792 allocs/op
BenchmarkLoaderChunkVisibilityThroughput-20    	     100	   1742160 ns/op	  628958 B/op	     968 allocs/op
BenchmarkLoaderChunkVisibilityThroughput-20    	     100	   2161413 ns/op	  867688 B/op	    1013 allocs/op
BenchmarkLoaderChunkVisibilityThroughput-20    	     100	   1438624 ns/op	  680387 B/op	     823 allocs/op
BenchmarkWorldExecLatencyDuringChunkLoad-20    	     100	     16429 ns/op	     203 B/op	       4 allocs/op
BenchmarkWorldExecLatencyDuringChunkLoad-20    	     100	     10581 ns/op	     208 B/op	       4 allocs/op
BenchmarkWorldExecLatencyDuringChunkLoad-20    	     100	     11769 ns/op	     203 B/op	       4 allocs/op
BenchmarkWorldExecLatencyDuringChunkLoad-20    	     100	      5262 ns/op	     202 B/op	       4 allocs/op
BenchmarkWorldExecLatencyDuringChunkLoad-20    	     100	     13695 ns/op	     203 B/op	       4 allocs/op
PASS
ok  	github.com/df-mc/dragonfly/server/world	3.022s
```

These numbers are from a local benchmark run and should be interpreted as directional rather than absolute.

</details>

## Backward Compatibility

The primary behavior change is that `Loader.Load` no longer synchronously loads or generates missing chunks. It now only sends chunks that have already been committed to the world, while missing chunks are queued for asynchronous preparation and sent by a later load tick after they are committed.

Code that relies on `Loader.Load` immediately materializing a missing chunk may need to be updated to handle delayed availability.

`Provider` and `Generator` interfaces are unchanged. Calls to them are serialized internally, so existing implementations are not required to be safe for concurrent use.

## In-Game Tests

* Old behaviour
https://streamable.com/kyjh77

* New behaviour
https://streamable.com/5cxibg

Tests have been recorded with NopProvider which generates new chunk every server startup.