### PR TITLE
server/block: Implement bonemeal huge growth particles

### DIFF
--- a/server/block/beetroot_seeds.go
+++ b/server/block/beetroot_seeds.go
@@ -21,16 +21,16 @@ func (BeetrootSeeds) SameCrop(c Crop) bool {
 }
 
 // BoneMeal ...
-func (b BeetrootSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (b BeetrootSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if b.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	if rand.Float64() < 0.75 {
 		b.Growth++
 		tx.SetBlock(pos, b, nil)
-		return true
+		return item.BoneMealResultSmall
 	}
-	return false
+	return item.BoneMealResultNone
 }
 
 // UseOnBlock ...

--- a/server/block/carrot.go
+++ b/server/block/carrot.go
@@ -38,13 +38,13 @@ func (c Carrot) Consume(_ *world.Tx, co item.Consumer) item.Stack {
 }
 
 // BoneMeal ...
-func (c Carrot) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (c Carrot) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if c.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	c.Growth = min(c.Growth+rand.IntN(4)+2, 7)
 	tx.SetBlock(pos, c, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/cocoa_bean.go
+++ b/server/block/cocoa_bean.go
@@ -1,12 +1,13 @@
 package block
 
 import (
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/model"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
 )
 
 // CocoaBean is a crop block found in jungle biomes.
@@ -20,13 +21,13 @@ type CocoaBean struct {
 }
 
 // BoneMeal ...
-func (c CocoaBean) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (c CocoaBean) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if c.Age == 2 {
-		return false
+		return item.BoneMealResultNone
 	}
 	c.Age++
 	tx.SetBlock(pos, c, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // HasLiquidDrops ...

--- a/server/block/double_flower.go
+++ b/server/block/double_flower.go
@@ -24,9 +24,9 @@ func (d DoubleFlower) FlammabilityInfo() FlammabilityInfo {
 }
 
 // BoneMeal ...
-func (d DoubleFlower) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (d DoubleFlower) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	dropItem(tx, item.NewStack(d, 1), pos.Vec3Centre())
-	return true
+	return item.BoneMealResultSmall
 }
 
 // NeighbourUpdateTick ...

--- a/server/block/fern.go
+++ b/server/block/fern.go
@@ -25,14 +25,14 @@ func (g Fern) BreakInfo() BreakInfo {
 }
 
 // BoneMeal attempts to affect the block using a bone meal item.
-func (g Fern) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (g Fern) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	upper := DoubleTallGrass{Type: FernDoubleTallGrass(), UpperPart: true}
 	if replaceableWith(tx, pos.Side(cube.FaceUp), upper) {
 		tx.SetBlock(pos, DoubleTallGrass{Type: FernDoubleTallGrass()}, nil)
 		tx.SetBlock(pos.Side(cube.FaceUp), upper, nil)
-		return true
+		return item.BoneMealResultSmall
 	}
-	return false
+	return item.BoneMealResultNone
 }
 
 // CompostChance ...

--- a/server/block/flower.go
+++ b/server/block/flower.go
@@ -1,13 +1,14 @@
 package block
 
 import (
+	"math/rand/v2"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/entity/effect"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
-	"time"
 )
 
 // Flower is a non-solid plant that occur in a variety of shapes and colours. They are primarily used for decoration
@@ -32,7 +33,7 @@ func (f Flower) EntityInside(_ cube.Pos, _ *world.Tx, e world.Entity) {
 }
 
 // BoneMeal ...
-func (f Flower) BoneMeal(pos cube.Pos, tx *world.Tx) (success bool) {
+func (f Flower) BoneMeal(pos cube.Pos, tx *world.Tx) (result item.BoneMealResult) {
 	if f.Type == WitherRose() {
 		return
 	}
@@ -54,7 +55,7 @@ func (f Flower) BoneMeal(pos cube.Pos, tx *world.Tx) (success bool) {
 			}
 		}
 		tx.SetBlock(p, Flower{Type: flowerType}, nil)
-		success = true
+		result = item.BoneMealResultHuge
 	}
 	return
 }

--- a/server/block/flower.go
+++ b/server/block/flower.go
@@ -55,7 +55,7 @@ func (f Flower) BoneMeal(pos cube.Pos, tx *world.Tx) (result item.BoneMealResult
 			}
 		}
 		tx.SetBlock(p, Flower{Type: flowerType}, nil)
-		result = item.BoneMealResultHuge
+		result = item.BoneMealResultArea
 	}
 	return
 }

--- a/server/block/flower.go
+++ b/server/block/flower.go
@@ -34,6 +34,7 @@ func (f Flower) EntityInside(_ cube.Pos, _ *world.Tx, e world.Entity) {
 
 // BoneMeal ...
 func (f Flower) BoneMeal(pos cube.Pos, tx *world.Tx) (result item.BoneMealResult) {
+	result = item.BoneMealResultNone
 	if f.Type == WitherRose() {
 		return
 	}

--- a/server/block/grass.go
+++ b/server/block/grass.go
@@ -82,8 +82,7 @@ func (g Grass) RandomTick(pos cube.Pos, tx *world.Tx, r *rand.Rand) {
 // BoneMeal ...
 func (g Grass) BoneMeal(pos cube.Pos, tx *world.Tx) (result item.BoneMealResult) {
 	result = item.BoneMealResultNone
-
-	for i := 0; i < 14; i++ {
+	for range 14 {
 		c := pos.Add(cube.Pos{rand.IntN(6) - 3, 0, rand.IntN(6) - 3})
 		above := c.Side(cube.FaceUp)
 		_, air := tx.Block(above).(Air)

--- a/server/block/grass.go
+++ b/server/block/grass.go
@@ -90,7 +90,7 @@ func (g Grass) BoneMeal(pos cube.Pos, tx *world.Tx) (result item.BoneMealResult)
 		_, grass := tx.Block(c).(Grass)
 		if air && grass {
 			tx.SetBlock(above, plantSelection[rand.IntN(len(plantSelection))], nil)
-			result = item.BoneMealResultHuge
+			result = item.BoneMealResultArea
 		}
 	}
 	return

--- a/server/block/grass.go
+++ b/server/block/grass.go
@@ -4,6 +4,7 @@ import (
 	"math/rand/v2"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 )
 
@@ -79,7 +80,9 @@ func (g Grass) RandomTick(pos cube.Pos, tx *world.Tx, r *rand.Rand) {
 }
 
 // BoneMeal ...
-func (g Grass) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (g Grass) BoneMeal(pos cube.Pos, tx *world.Tx) (result item.BoneMealResult) {
+	result = item.BoneMealResultNone
+
 	for i := 0; i < 14; i++ {
 		c := pos.Add(cube.Pos{rand.IntN(6) - 3, 0, rand.IntN(6) - 3})
 		above := c.Side(cube.FaceUp)
@@ -87,10 +90,10 @@ func (g Grass) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
 		_, grass := tx.Block(c).(Grass)
 		if air && grass {
 			tx.SetBlock(above, plantSelection[rand.IntN(len(plantSelection))], nil)
+			result = item.BoneMealResultHuge
 		}
 	}
-
-	return true
+	return
 }
 
 // BreakInfo ...

--- a/server/block/kelp.go
+++ b/server/block/kelp.go
@@ -1,11 +1,12 @@
 package block
 
 import (
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
 )
 
 // Kelp is an underwater block which can grow on top of solids underwater.
@@ -24,7 +25,7 @@ func (k Kelp) SmeltInfo() item.SmeltInfo {
 }
 
 // BoneMeal ...
-func (k Kelp) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (k Kelp) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	for y := pos.Y(); y <= tx.Range()[1]; y++ {
 		currentPos := cube.Pos{pos.X(), y, pos.Z()}
 		block := tx.Block(currentPos)
@@ -36,11 +37,11 @@ func (k Kelp) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
 		}
 		if water, ok := block.(Water); ok && water.Depth == 8 {
 			tx.SetBlock(currentPos, Kelp{Age: k.Age + 1}, nil)
-			return true
+			return item.BoneMealResultSmall
 		}
 		break
 	}
-	return false
+	return item.BoneMealResultNone
 }
 
 // BreakInfo ...

--- a/server/block/melon_seeds.go
+++ b/server/block/melon_seeds.go
@@ -1,11 +1,12 @@
 package block
 
 import (
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
 )
 
 // MelonSeeds grow melon blocks.
@@ -62,13 +63,13 @@ func (m MelonSeeds) RandomTick(pos cube.Pos, tx *world.Tx, r *rand.Rand) {
 }
 
 // BoneMeal ...
-func (m MelonSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (m MelonSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if m.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	m.Growth = min(m.Growth+rand.IntN(4)+2, 7)
 	tx.SetBlock(pos, m, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/pink_petals.go
+++ b/server/block/pink_petals.go
@@ -21,14 +21,14 @@ type PinkPetals struct {
 }
 
 // BoneMeal ...
-func (p PinkPetals) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (p PinkPetals) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if p.AdditionalCount < 3 {
 		p.AdditionalCount++
 		tx.SetBlock(pos, p, nil)
-		return true
+		return item.BoneMealResultSmall
 	}
 	dropItem(tx, item.NewStack(p, 1), pos.Vec3Centre())
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/potato.go
+++ b/server/block/potato.go
@@ -43,13 +43,13 @@ func (p Potato) Consume(_ *world.Tx, c item.Consumer) item.Stack {
 }
 
 // BoneMeal ...
-func (p Potato) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (p Potato) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if p.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	p.Growth = min(p.Growth+rand.IntN(4)+2, 7)
 	tx.SetBlock(pos, p, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/pumpkin_seeds.go
+++ b/server/block/pumpkin_seeds.go
@@ -1,11 +1,12 @@
 package block
 
 import (
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
 )
 
 // PumpkinSeeds grow pumpkin blocks.
@@ -62,13 +63,13 @@ func (p PumpkinSeeds) RandomTick(pos cube.Pos, tx *world.Tx, r *rand.Rand) {
 }
 
 // BoneMeal ...
-func (p PumpkinSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (p PumpkinSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if p.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	p.Growth = min(p.Growth+rand.IntN(4)+2, 7)
 	tx.SetBlock(pos, p, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/sea_pickle.go
+++ b/server/block/sea_pickle.go
@@ -1,12 +1,13 @@
 package block
 
 import (
+	"math"
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math"
-	"math/rand/v2"
 )
 
 // SeaPickle is a small stationary underwater block that emits light, and is typically found in colonies of up to
@@ -41,12 +42,12 @@ func (SeaPickle) canSurvive(pos cube.Pos, tx *world.Tx) bool {
 }
 
 // BoneMeal ...
-func (s SeaPickle) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (s SeaPickle) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if s.Dead {
-		return false
+		return item.BoneMealResultNone
 	}
 	if coral, ok := tx.Block(pos.Side(cube.FaceDown)).(CoralBlock); !ok || coral.Dead {
-		return false
+		return item.BoneMealResultNone
 	}
 
 	if s.AdditionalCount != 3 {
@@ -74,7 +75,7 @@ func (s SeaPickle) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
 		}
 	}
 
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/short_grass.go
+++ b/server/block/short_grass.go
@@ -27,14 +27,14 @@ func (g ShortGrass) BreakInfo() BreakInfo {
 }
 
 // BoneMeal attempts to affect the block using a bone meal item.
-func (g ShortGrass) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (g ShortGrass) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	upper := DoubleTallGrass{Type: NormalDoubleTallGrass(), UpperPart: true}
 	if replaceableWith(tx, pos.Side(cube.FaceUp), upper) {
 		tx.SetBlock(pos, DoubleTallGrass{Type: NormalDoubleTallGrass()}, nil)
 		tx.SetBlock(pos.Side(cube.FaceUp), upper, nil)
-		return true
+		return item.BoneMealResultSmall
 	}
-	return false
+	return item.BoneMealResultNone
 }
 
 // CompostChance ...

--- a/server/block/sugar_cane.go
+++ b/server/block/sugar_cane.go
@@ -1,11 +1,12 @@
 package block
 
 import (
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
 )
 
 // SugarCane is a plant block that generates naturally near water.
@@ -63,7 +64,7 @@ func (c SugarCane) RandomTick(pos cube.Pos, tx *world.Tx, _ *rand.Rand) {
 }
 
 // BoneMeal ...
-func (c SugarCane) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (c SugarCane) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	for _, ok := tx.Block(pos.Side(cube.FaceDown)).(SugarCane); ok; _, ok = tx.Block(pos.Side(cube.FaceDown)).(SugarCane) {
 		pos = pos.Side(cube.FaceDown)
 	}
@@ -73,9 +74,9 @@ func (c SugarCane) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
 				tx.SetBlock(pos.Add(cube.Pos{0, y}), SugarCane{}, nil)
 			}
 		}
-		return true
+		return item.BoneMealResultSmall
 	}
-	return false
+	return item.BoneMealResultNone
 }
 
 // canGrowHere implements logic to check if sugar cane can live/grow here.

--- a/server/block/wheat_seeds.go
+++ b/server/block/wheat_seeds.go
@@ -21,13 +21,13 @@ func (WheatSeeds) SameCrop(c Crop) bool {
 }
 
 // BoneMeal ...
-func (s WheatSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (s WheatSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if s.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	s.Growth = min(s.Growth+rand.IntN(4)+2, 7)
 	tx.SetBlock(pos, s, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/item/bone_meal.go
+++ b/server/item/bone_meal.go
@@ -7,20 +7,35 @@ import (
 	"github.com/go-gl/mathgl/mgl64"
 )
 
+type BoneMealResult int
+
+const (
+	BoneMealResultNone BoneMealResult = iota
+	BoneMealResultSmall
+	BoneMealResultHuge
+)
+
 // BoneMeal is an item used to force growth in plants & crops.
 type BoneMeal struct{}
 
 // BoneMealAffected represents a block that is affected when bone meal is used on it.
 type BoneMealAffected interface {
 	// BoneMeal attempts to affect the block using a bone meal item.
-	BoneMeal(pos cube.Pos, tx *world.Tx) bool
+	BoneMeal(pos cube.Pos, tx *world.Tx) BoneMealResult
 }
 
 // UseOnBlock ...
 func (b BoneMeal) UseOnBlock(pos cube.Pos, _ cube.Face, _ mgl64.Vec3, tx *world.Tx, _ User, ctx *UseContext) bool {
-	if bm, ok := tx.Block(pos).(BoneMealAffected); ok && bm.BoneMeal(pos, tx) {
+	if bm, ok := tx.Block(pos).(BoneMealAffected); ok {
+		result := bm.BoneMeal(pos, tx)
+		if result == BoneMealResultNone {
+			return false
+		}
+
 		ctx.SubtractFromCount(1)
-		tx.AddParticle(pos.Vec3(), particle.BoneMeal{})
+		tx.AddParticle(pos.Vec3(), particle.BoneMeal{
+			Huge: result == BoneMealResultHuge,
+		})
 		return true
 	}
 	return false

--- a/server/item/bone_meal.go
+++ b/server/item/bone_meal.go
@@ -7,11 +7,16 @@ import (
 	"github.com/go-gl/mathgl/mgl64"
 )
 
+// BoneMealResult represents the outcome of a bone meal interaction with a block,
+// determining the intensity of the particle effect displayed.
 type BoneMealResult int
 
 const (
+	// BoneMealResultNone indicates that the bone meal had no effect on the block.
 	BoneMealResultNone BoneMealResult = iota
+	// BoneMealResultSmall indicates a minor growth effect, produces a small particle burst.
 	BoneMealResultSmall
+	// BoneMealResultArea indicates a significant growth effect over an area, produces a large particle burst.
 	BoneMealResultArea
 )
 

--- a/server/item/bone_meal.go
+++ b/server/item/bone_meal.go
@@ -12,7 +12,7 @@ type BoneMealResult int
 const (
 	BoneMealResultNone BoneMealResult = iota
 	BoneMealResultSmall
-	BoneMealResultHuge
+	BoneMealResultArea
 )
 
 // BoneMeal is an item used to force growth in plants & crops.
@@ -34,7 +34,7 @@ func (b BoneMeal) UseOnBlock(pos cube.Pos, _ cube.Face, _ mgl64.Vec3, tx *world.
 
 		ctx.SubtractFromCount(1)
 		tx.AddParticle(pos.Vec3(), particle.BoneMeal{
-			Huge: result == BoneMealResultHuge,
+			Area: result == BoneMealResultArea,
 		})
 		return true
 	}

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -381,14 +381,14 @@ func (s *Session) ViewParticle(pos mgl64.Vec3, p world.Particle) {
 			Position:  vec64To32(pos),
 		})
 	case particle.BoneMeal:
-		var count int32
-		if pa.Huge {
-			count = 5
+		var area int32
+		if pa.Area {
+			area = 1
 		}
 		s.writePacket(&packet.LevelEvent{
 			EventType: packet.LevelEventParticleCropGrowth,
 			Position:  vec64To32(pos),
-			EventData: count,
+			EventData: area,
 		})
 	case particle.BlockForceField:
 		s.writePacket(&packet.LevelEvent{

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -381,14 +381,10 @@ func (s *Session) ViewParticle(pos mgl64.Vec3, p world.Particle) {
 			Position:  vec64To32(pos),
 		})
 	case particle.BoneMeal:
-		var area int32
-		if pa.Area {
-			area = 1
-		}
 		s.writePacket(&packet.LevelEvent{
 			EventType: packet.LevelEventParticleCropGrowth,
 			Position:  vec64To32(pos),
-			EventData: area,
+			EventData: int32(boolByte(pa.Area)),
 		})
 	case particle.BlockForceField:
 		s.writePacket(&packet.LevelEvent{

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -381,7 +381,7 @@ func (s *Session) ViewParticle(pos mgl64.Vec3, p world.Particle) {
 			Position:  vec64To32(pos),
 		})
 	case particle.BoneMeal:
-		var count int32 = 0
+		var count int32
 		if pa.Huge {
 			count = 5
 		}

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -381,9 +381,14 @@ func (s *Session) ViewParticle(pos mgl64.Vec3, p world.Particle) {
 			Position:  vec64To32(pos),
 		})
 	case particle.BoneMeal:
+		var count int32 = 0
+		if pa.Huge {
+			count = 5
+		}
 		s.writePacket(&packet.LevelEvent{
 			EventType: packet.LevelEventParticleCropGrowth,
 			Position:  vec64To32(pos),
+			EventData: count,
 		})
 	case particle.BlockForceField:
 		s.writePacket(&packet.LevelEvent{

--- a/server/world/particle/block.go
+++ b/server/world/particle/block.go
@@ -53,10 +53,10 @@ type BlockForceField struct{ particle }
 type BoneMeal struct {
 	particle
 
-	// Huge specifies whether the particle effect should be large. If false,
+	// Area specifies whether the particle effect should be for area. If false,
 	// a small burst is used for minor growth. If true, a large burst is used
 	// for significant growth.
-	Huge bool
+	Area bool
 }
 
 // Note is a particle that shows up on note block interactions.

--- a/server/world/particle/block.go
+++ b/server/world/particle/block.go
@@ -1,11 +1,12 @@
 package particle
 
 import (
+	"image/color"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/sound"
 	"github.com/go-gl/mathgl/mgl64"
-	"image/color"
 )
 
 // Flame is a particle shown around torches. It can have any colour specified with the Colour field.
@@ -49,7 +50,14 @@ type PunchBlock struct {
 type BlockForceField struct{ particle }
 
 // BoneMeal is a particle that shows up on bone meal usage.
-type BoneMeal struct{ particle }
+type BoneMeal struct {
+	particle
+
+	// Huge specifies whether the particle effect should be large. If false,
+	// a small burst is used for minor growth. If true, a large burst is used
+	// for significant growth.
+	Huge bool
+}
 
 // Note is a particle that shows up on note block interactions.
 type Note struct {


### PR DESCRIPTION
This PR implements displaying huge growth particles when the player interacts using bone meal on grass and flowers to match vanilla

Changes:
- `item.BoneMealAffected.BoneMeal` now returns `BoneMealResult` allowing to select how fertiliser particles will be displayed
- `block.Grass.BoneMeal` now returns `BoneMealResultNone` if method made no changes
- `particle.BoneMeal` now has `Area` field, that allows to specify whether the particle is for area, not for a single block


Showcase:

https://github.com/user-attachments/assets/49e62bb8-8cd6-46b4-bb69-e5ee7224d5d0


