### PR TITLE
Read full level.dat data with io.ReadFull

### DIFF
--- a/server/world/mcdb/leveldat/level_dat.go
+++ b/server/world/mcdb/leveldat/level_dat.go
@@ -4,9 +4,10 @@ import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
-	"github.com/sandertv/gophertunnel/minecraft/nbt"
 	"io"
 	"os"
+
+	"github.com/sandertv/gophertunnel/minecraft/nbt"
 )
 
 // LevelDat implements the encoding and decoding of level.dat files. An empty
@@ -40,7 +41,7 @@ func Read(r io.Reader) (*LevelDat, error) {
 		return nil, fmt.Errorf("level.dat: read header: %w", err)
 	}
 	ldat.data = make([]byte, ldat.hdr.FileLength)
-	if n, err := r.Read(ldat.data); err != nil || int32(n) != ldat.hdr.FileLength {
+	if n, err := io.ReadFull(r, ldat.data); err != nil || int32(n) != ldat.hdr.FileLength {
 		return nil, fmt.Errorf("level.dat: read data: %w", err)
 	}
 	return &ldat, nil


### PR DESCRIPTION
Replace a direct r.Read call with io.ReadFull when reading the level.dat data to ensure the full FileLength bytes are read (r.Read can return partial reads). Also adjust imports ordering to group standard library and external packages.