### PR TITLE
crossbow.go: Fix crossbow charging animation played even if the player has no suitable item to insert projectile into it

### DIFF
--- a/server/item/crossbow.go
+++ b/server/item/crossbow.go
@@ -154,6 +154,12 @@ func (c Crossbow) ReleaseCharge(releaser Releaser, tx *world.Tx, ctx *UseContext
 	return true
 }
 
+// CanCharge ...
+func (c Crossbow) CanCharge(releaser Releaser, tx *world.Tx, ctx *UseContext) bool {
+	_, found := c.findProjectile(releaser, ctx)
+	return found && !c.Item.Empty()
+}
+
 // shoot fires the crossbow's loaded projectiles.
 func (c Crossbow) shoot(releaser Releaser, tx *world.Tx, offsetAngle float64, arrowConf world.ArrowSpawnConfig) {
 	rot := releaser.Rotation()

--- a/server/item/crossbow.go
+++ b/server/item/crossbow.go
@@ -155,7 +155,7 @@ func (c Crossbow) ReleaseCharge(releaser Releaser, tx *world.Tx, ctx *UseContext
 }
 
 // CanCharge ...
-func (c Crossbow) CanCharge(releaser Releaser, tx *world.Tx, ctx *UseContext) bool {
+func (c Crossbow) CanCharge(releaser Releaser, _ *world.Tx, ctx *UseContext) bool {
 	_, found := c.findProjectile(releaser, ctx)
 	return found && !c.Item.Empty()
 }

--- a/server/item/item.go
+++ b/server/item/item.go
@@ -2,12 +2,13 @@ package item
 
 import (
 	"encoding/binary"
+	"image/color"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/entity/effect"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"image/color"
-	"time"
 )
 
 // MaxCounter represents an item that has a specific max count. By default, each item will be expected to have
@@ -168,6 +169,8 @@ type Chargeable interface {
 	ContinueCharge(releaser Releaser, tx *world.Tx, ctx *UseContext, duration time.Duration)
 	// ReleaseCharge is called when an item is being released.
 	ReleaseCharge(releaser Releaser, tx *world.Tx, ctx *UseContext) bool
+	// CanCharge returns whether the item can currently be charged.
+	CanCharge(releaser Releaser, tx *world.Tx, ctx *UseContext) bool
 }
 
 // User represents an entity that is able to use an item in the world, typically entities such as players,

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1512,7 +1512,7 @@ func (p *Player) UseItem() {
 	case item.Chargeable:
 		useCtx := p.useContext()
 		if !p.usingItem {
-			if !usable.ReleaseCharge(p, p.tx, useCtx) {
+			if !usable.ReleaseCharge(p, p.tx, useCtx) && usable.CanCharge(p, p.tx, useCtx) {
 				// If the item was not charged yet, start charging.
 				p.usingSince, p.usingItem = time.Now(), true
 			}


### PR DESCRIPTION
## Changes:
- Added `CanCharge` method into `Releasable` interface

## Tests:

### Before:
https://github.com/user-attachments/assets/a7d7d5ed-d094-48fd-8ad7-c7409aea29a8
### After:
https://github.com/user-attachments/assets/e3105874-341c-4be4-b651-7970e84c2da5

