### PR TITLE
session/session.go: fix panic when sessionless player logs

### DIFF
--- a/server/session/session.go
+++ b/server/session/session.go
@@ -144,7 +144,7 @@ type Conn interface {
 }
 
 // Nop represents a no-operation session. It does not do anything when sending a packet to it.
-var Nop = &Session{}
+var Nop = &Session{conf: Config{Log: slog.Default()}}
 
 // selfEntityRuntimeID is the entity runtime (or unique) ID of the controllable that the session holds.
 const selfEntityRuntimeID = 1

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -144,7 +144,7 @@ type Conn interface {
 }
 
 // Nop represents a no-operation session. It does not do anything when sending a packet to it.
-var Nop = &Session{conf: Config{Log: slog.Default()}}
+var Nop = &Session{conf: Config{Log: slog.New(slog.DiscardHandler)}}
 
 // selfEntityRuntimeID is the entity runtime (or unique) ID of the controllable that the session holds.
 const selfEntityRuntimeID = 1


### PR DESCRIPTION
sessionless players are not really sessionless, they rely on the nop session, and when it tries to log something, if the logger is nil, it panics