### PR TITLE
world/chunk/decode.go: Fix panic on out-of-range sub chunk index in NetworkDecode

### DIFF
--- a/server/world/chunk/decode.go
+++ b/server/world/chunk/decode.go
@@ -23,16 +23,21 @@ func NetworkDecode(br BlockRegistry, data []byte, count int, r cube.Range) (*Chu
 // The sub chunk count passed must be that found in the LevelChunk packet.
 // noinspection GoUnusedExportedFunction
 func NetworkDecodeBuffer(br BlockRegistry, buf *bytes.Buffer, count int, r cube.Range) (*Chunk, error) {
-	var (
-		c   = New(br, r)
-		err error
-	)
+	c := New(br, r)
 	for i := 0; i < count; i++ {
 		index := uint8(i)
-		c.sub[index], err = decodeSubChunk(buf, c, &index, NetworkEncoding)
+		sub, err := decodeSubChunk(buf, c, &index, NetworkEncoding)
 		if err != nil {
 			return nil, err
 		}
+		// A version 9 sub chunk encodes its own Y index, which is read from the
+		// untrusted network data and translated to a sub chunk index. A malicious
+		// sender may craft an index outside the chunk's range, so guard against it
+		// before indexing c.sub to avoid an out of range panic.
+		if int(index) >= len(c.sub) {
+			return nil, fmt.Errorf("sub chunk index %v out of range (length %v)", index, len(c.sub))
+		}
+		c.sub[index] = sub
 	}
 	var last *PalettedStorage
 	for i := 0; i < len(c.sub); i++ {


### PR DESCRIPTION
This fixes a denial-of-service panic when decoding chunk data received over the network.

A version 9 sub chunk encodes its own Y index in the network payload. That value is attacker-controlled and was translated into an index into `c.sub` without any bounds check, so a crafted `LevelChunk` packet (for example from a malicious proxy) could index `c.sub` out of range and crash the server with a runtime panic (`index out of range [109] with length 24`).

`NetworkDecodeBuffer` now captures the decoded sub chunk, validates the resulting index against `len(c.sub)` and returns an error instead of panicking, letting the caller fall back to an empty chunk.

This follows the fix suggested in the issue thread, with the off-by-one corrected (`>= len(c.sub)` rather than `> n`, so an index exactly equal to the length is also rejected).

Fixes #1024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)