### PR TITLE
Add RuntimeIDToHash to chunk registry

### DIFF
--- a/server/world/chunk/block_registry.go
+++ b/server/world/chunk/block_registry.go
@@ -27,4 +27,6 @@ type BlockRegistry interface {
 	LiquidBlock(rid uint32) bool
 	// HashToRuntimeID resolves a "network block hash" to a runtime ID.
 	HashToRuntimeID(hash uint32) (rid uint32, ok bool)
+	// RuntimeIDToHash resolves a runtime ID to its "network block hash".
+	RuntimeIDToHash(runtimeID uint32) (hash uint32, ok bool)
 }


### PR DESCRIPTION
Adds RuntimeIDToHash to the chunk block registry interface.
this method already exists, forgot to add it to the interface when i implemented