### PR TITLE
server/player, server/session: Fix fall state handing

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -539,11 +539,12 @@ func (p *Player) Heal(health float64, source world.HealingSource) {
 func (p *Player) updateFallState(distanceThisTick float64) {
 	switch {
 	case p.OnGround():
-		if p.fallDistance > 0 {
+		p.fallDistance -= distanceThisTick
+		if p.fallDistance > 3 {
 			p.fall(p.fallDistance)
-			p.ResetFallDistance()
 		}
-	case distanceThisTick < p.fallDistance:
+		p.ResetFallDistance()
+	case distanceThisTick < 0 && distanceThisTick < p.fallDistance:
 		p.fallDistance -= distanceThisTick
 	default:
 		p.ResetFallDistance()
@@ -2193,6 +2194,8 @@ func (p *Player) teleport(pos mgl64.Vec3) {
 // Move also rotates the player, adding deltaYaw and deltaPitch to the respective values.
 func (p *Player) Move(deltaPos mgl64.Vec3, deltaYaw, deltaPitch float64) {
 	if p.Dead() || (deltaPos.ApproxEqual(mgl64.Vec3{}) && mgl64.FloatEqual(deltaYaw, 0) && mgl64.FloatEqual(deltaPitch, 0)) {
+		p.onGround = true
+		p.updateFallState(deltaPos.Y())
 		return
 	}
 	if p.immobile {
@@ -2251,7 +2254,7 @@ func (p *Player) Move(deltaPos mgl64.Vec3, deltaYaw, deltaPitch float64) {
 	}
 
 	p.onGround = p.checkOnGround(deltaPos)
-	p.updateFallState(deltaPos[1])
+	p.updateFallState(deltaPos.Y())
 
 	if p.Swimming() {
 		p.Exhaust(0.01 * horizontalVel.Len())

--- a/server/session/handler_player_auth_input.go
+++ b/server/session/handler_player_auth_input.go
@@ -46,20 +46,19 @@ func (h PlayerAuthInputHandler) handleMovement(pk *packet.PlayerAuthInput, s *Se
 
 	newPos := vec32To64(pk.Position)
 	deltaPos, deltaYaw, deltaPitch := newPos.Sub(pos), float64(pk.Yaw)-yaw, float64(pk.Pitch)-pitch
-	if mgl64.FloatEqual(deltaPos.Len(), 0) && mgl64.FloatEqual(deltaYaw, 0) && mgl64.FloatEqual(deltaPitch, 0) {
-		// The PlayerAuthInput packet is sent every tick, so don't do anything if the position and rotation
-		// were unchanged.
-		return nil
-	}
 
-	if expected := s.teleportPos.Load(); expected != nil {
-		if newPos.Sub(*expected).Len() > 1 {
-			// The player has moved before it received the teleport packet. Ignore this movement entirely and
-			// wait for the client to sync itself back to the server. Once we get a movement that is close
-			// enough to the teleport position, we'll allow the player to move around again.
-			return nil
+	// The PlayerAuthInput packet is sent every tick, so don't check for teleport if the position and rotation
+	// were unchanged.
+	if !mgl64.FloatEqual(deltaPos.Len(), 0) || !mgl64.FloatEqual(deltaYaw, 0) || !mgl64.FloatEqual(deltaPitch, 0) {
+		if expected := s.teleportPos.Load(); expected != nil {
+			if newPos.Sub(*expected).Len() > 1 {
+				// The player has moved before it received the teleport packet. Ignore this movement entirely and
+				// wait for the client to sync itself back to the server. Once we get a movement that is close
+				// enough to the teleport position, we'll allow the player to move around again.
+				return nil
+			}
+			s.teleportPos.Store(nil)
 		}
-		s.teleportPos.Store(nil)
 	}
 
 	s.moving = true


### PR DESCRIPTION
Fixes issue of fallDistance not resetting while flying.
Steps to reproduce:
* Start falling.
* Start flying before you hit the ground.
* Go down to a point where u shouldn't take fall damage.
* Stop flying.