### PR TITLE
world: add synchronous mode for deterministic, in-process worlds

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,3 +17,6 @@ jobs:
 
       - name: Lint
         run: make lint
+
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Lint
         run: make lint
 
+      - name: Test
+        run: go test ./...
+
   deploy:
     name: Deploy
     needs: build

--- a/server/block/block_behaviour_test.go
+++ b/server/block/block_behaviour_test.go
@@ -1,0 +1,32 @@
+package block_test
+
+import (
+	"testing"
+
+	"github.com/df-mc/dragonfly/server/block"
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/entity"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+// TestTorchBreaksWithoutSupport verifies that a torch is broken by a neighbour
+// update on the tick after its supporting block is removed, using a
+// synchronous World to make the tick deterministic.
+func TestTorchBreaksWithoutSupport(t *testing.T) {
+	w := world.Config{Synchronous: true, Entities: entity.DefaultRegistry}.New()
+	defer w.Close()
+
+	support, torch := cube.Pos{0, 0, 0}, cube.Pos{0, 1, 0}
+	<-w.Exec(func(tx *world.Tx) {
+		tx.SetBlock(support, block.Stone{}, nil)
+		tx.SetBlock(torch, block.Torch{Facing: cube.FaceDown}, nil)
+		tx.SetBlock(support, block.Air{}, nil)
+	})
+	w.AdvanceTick()
+
+	<-w.Exec(func(tx *world.Tx) {
+		if b := tx.Block(torch); b != (block.Air{}) {
+			t.Errorf("expected torch to break after removing its support, got %v", b)
+		}
+	})
+}

--- a/server/world/conf.go
+++ b/server/world/conf.go
@@ -77,6 +77,9 @@ type Config struct {
 	// not saved or unloaded automatically, and time only passes on explicit
 	// World.AdvanceTick calls. This makes Synchronous Worlds deterministic and
 	// well suited to unit tests that need a World to interact with.
+	// A Synchronous World must be driven from one goroutine. Exec and
+	// AdvanceTick are not safe to call concurrently, including from delayed
+	// item or death callbacks.
 	Synchronous bool
 }
 

--- a/server/world/conf.go
+++ b/server/world/conf.go
@@ -71,6 +71,13 @@ type Config struct {
 	// If left nil, DefaultBlockRegistry is used. For a non-default registry,
 	// use NewBlockRegistry(), register blocks/states, and call Finalize().
 	Blocks BlockRegistry
+
+	// Synchronous makes the World run without any background goroutines.
+	// Transactions from World.Exec run on the calling goroutine, the World is
+	// not saved or unloaded automatically, and time only passes on explicit
+	// World.AdvanceTick calls. This makes Synchronous Worlds deterministic and
+	// well suited to unit tests that need a World to interact with.
+	Synchronous bool
 }
 
 // New creates a new World using the Config conf. The World returned will start
@@ -135,13 +142,15 @@ func (conf Config) New() *World {
 	var h Handler = NopHandler{}
 	w.handler.Store(&h)
 
-	w.queueing.Add(1)
-	w.running.Add(2)
-
 	t := ticker{interval: time.Second / 20}
-	go t.tickLoop(w)
-	go w.autoSave()
-	go w.handleTransactions()
+	if !conf.Synchronous {
+		w.queueing.Add(1)
+		w.running.Add(2)
+
+		go t.tickLoop(w)
+		go w.autoSave()
+		go w.handleTransactions()
+	}
 
 	<-w.Exec(t.tick)
 	return w

--- a/server/world/tick.go
+++ b/server/world/tick.go
@@ -33,6 +33,13 @@ func (t ticker) tickLoop(w *World) {
 	}
 }
 
+// AdvanceTick advances the World by a single tick. It is generally only useful
+// for Worlds created with Config.Synchronous set: other Worlds tick
+// automatically 20 times per second.
+func (w *World) AdvanceTick() {
+	<-w.Exec(ticker{}.tick)
+}
+
 // tick performs a tick on the World and updates the time, weather, blocks and
 // entities that require updates.
 func (t ticker) tick(tx *Tx) {
@@ -45,8 +52,9 @@ func (t ticker) tick(tx *Tx) {
 		// the player should spawn at the highest position in the world.
 		w.set.Spawn[1] = w.highestObstructingBlock(s[0], s[2]) + 1
 	}
-	if len(viewers) == 0 && w.set.CurrentTick != 0 {
-		// Don't continue ticking if no viewers are in the world.
+	if len(viewers) == 0 && w.set.CurrentTick != 0 && !w.conf.Synchronous {
+		// Don't continue ticking if no viewers are in the world. Synchronous
+		// worlds only tick on explicit AdvanceTick calls, so they always tick.
 		w.set.Unlock()
 		return
 	}

--- a/server/world/tick.go
+++ b/server/world/tick.go
@@ -35,7 +35,8 @@ func (t ticker) tickLoop(w *World) {
 
 // AdvanceTick advances the World by a single tick. It is generally only useful
 // for Worlds created with Config.Synchronous set: other Worlds tick
-// automatically 20 times per second.
+// automatically 20 times per second. Synchronous Worlds tick loaded chunks
+// even when no viewers are present.
 func (w *World) AdvanceTick() {
 	<-w.Exec(ticker{}.tick)
 }
@@ -121,8 +122,7 @@ func (t ticker) performNeighbourUpdates(tx *Tx) {
 	}
 }
 
-// tickBlocksRandomly executes random block ticks in each sub chunk in the world that has at least one viewer
-// registered from the viewers passed.
+// tickBlocksRandomly executes random block ticks in loaded chunks within range of loaders.
 func (t ticker) tickBlocksRandomly(tx *Tx, loaders []*Loader, tick int64) {
 	var (
 		r             = int32(tx.World().tickRange())
@@ -136,12 +136,16 @@ func (t ticker) tickBlocksRandomly(tx *Tx, loaders []*Loader, tick int64) {
 	}
 
 	loaded := make([]ChunkPos, 0, len(loaders))
-	for _, loader := range loaders {
-		loader.mu.RLock()
-		pos := loader.pos
-		loader.mu.RUnlock()
+	if tx.World().conf.Synchronous {
+		loaded = slices.Collect(maps.Keys(tx.World().chunks))
+	} else {
+		for _, loader := range loaders {
+			loader.mu.RLock()
+			pos := loader.pos
+			loader.mu.RUnlock()
 
-		loaded = append(loaded, pos)
+			loaded = append(loaded, pos)
+		}
 	}
 
 	for pos, c := range tx.World().chunks {
@@ -246,7 +250,7 @@ func (t ticker) tickEntities(tx *Tx, tick int64) {
 			}
 		}
 
-		if len(c.viewers) > 0 {
+		if tx.World().conf.Synchronous || len(c.viewers) > 0 {
 			if te, ok := e.(TickerEntity); ok {
 				te.Tick(tx, tick)
 			}

--- a/server/world/weather.go
+++ b/server/world/weather.go
@@ -207,6 +207,9 @@ func (w weather) tickLightning(tx *Tx) {
 // near the lightning strike. If there is no rain at the final position
 // selected, the lightning strike will fail.
 func (w weather) strikeLightning(tx *Tx, c ChunkPos) {
+	if w.w.conf.Entities.conf.Lightning == nil {
+		return
+	}
 	if pos := w.lightningPosition(tx, c); tx.ThunderingAt(cube.PosFromVec3(pos)) {
 		tx.AddEntity(w.w.conf.Entities.conf.Lightning(EntitySpawnOpts{Position: pos}))
 	}

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -120,15 +120,35 @@ func (w *World) BlockRegistry() BlockRegistry {
 type ExecFunc func(tx *Tx)
 
 // Exec performs a synchronised transaction f on a World. Exec returns a channel
-// that is closed once the transaction is complete.
+// that is closed once the transaction is complete. For Worlds created with
+// Config.Synchronous set, the transaction is executed on the calling goroutine
+// and the channel returned is closed when Exec returns.
 func (w *World) Exec(f ExecFunc) <-chan struct{} {
 	c := make(chan struct{})
-	w.queue <- normalTransaction{c: c, f: f}
+	ntx := normalTransaction{c: c, f: f}
+	if w.conf.Synchronous {
+		ntx.Run(w)
+		return c
+	}
+	w.queue <- ntx
 	return c
 }
 
 func (w *World) weakExec(invalid *atomic.Bool, cond *sync.Cond, f ExecFunc) <-chan bool {
 	c := make(chan bool, 1)
+	if w.conf.Synchronous {
+		// The caller checks c before waiting on cond, so unlike
+		// weakTransaction.Run, no locking on cond.L (still held by the
+		// caller here) or Broadcast is needed.
+		valid := !invalid.Load()
+		if valid {
+			tx := &Tx{w: w}
+			f(tx)
+			tx.close()
+		}
+		c <- valid
+		return c
+	}
 	w.queue <- weakTransaction{c: c, f: f, invalid: invalid, cond: cond}
 	return c
 }

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -140,6 +140,8 @@ func (w *World) weakExec(invalid *atomic.Bool, cond *sync.Cond, f ExecFunc) <-ch
 	if w.conf.Synchronous {
 		valid := !invalid.Load()
 		if valid {
+			// As in weakTransaction.Run, f must not run under cond.L: it may
+			// relock it, e.g. through RemoveEntity.
 			cond.L.Unlock()
 			tx := &Tx{w: w}
 			f(tx)

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -122,7 +122,8 @@ type ExecFunc func(tx *Tx)
 // Exec performs a synchronised transaction f on a World. Exec returns a channel
 // that is closed once the transaction is complete. For Worlds created with
 // Config.Synchronous set, the transaction is executed on the calling goroutine
-// and the channel returned is closed when Exec returns.
+// and the channel returned is closed when Exec returns. Awaiting a nested Exec
+// from within a transaction deadlocks on non-synchronous Worlds.
 func (w *World) Exec(f ExecFunc) <-chan struct{} {
 	c := make(chan struct{})
 	ntx := normalTransaction{c: c, f: f}
@@ -137,14 +138,13 @@ func (w *World) Exec(f ExecFunc) <-chan struct{} {
 func (w *World) weakExec(invalid *atomic.Bool, cond *sync.Cond, f ExecFunc) <-chan bool {
 	c := make(chan bool, 1)
 	if w.conf.Synchronous {
-		// The caller checks c before waiting on cond, so unlike
-		// weakTransaction.Run, no locking on cond.L (still held by the
-		// caller here) or Broadcast is needed.
 		valid := !invalid.Load()
 		if valid {
+			cond.L.Unlock()
 			tx := &Tx{w: w}
 			f(tx)
 			tx.close()
+			cond.L.Lock()
 		}
 		c <- valid
 		return c

--- a/server/world/world_test.go
+++ b/server/world/world_test.go
@@ -52,23 +52,6 @@ func TestSynchronousWorldAdvanceTick(t *testing.T) {
 	}
 }
 
-// TestSynchronousWorldClose verifies that closing a synchronous World returns
-// promptly instead of waiting for goroutines that were never started.
-func TestSynchronousWorldClose(t *testing.T) {
-	w := Config{Synchronous: true}.New()
-
-	done := make(chan struct{})
-	go func() {
-		_ = w.Close()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(time.Second * 5):
-		t.Fatal("Close did not return within 5 seconds")
-	}
-}
-
 func TestSynchronousExecWorldCanRemoveEntity(t *testing.T) {
 	w := Config{Synchronous: true}.New()
 	defer w.Close()
@@ -130,25 +113,6 @@ func TestSynchronousAdvanceTickTicksViewerlessBlockEntities(t *testing.T) {
 	if tb.ticks == 0 {
 		t.Fatal("expected block entity to tick")
 	}
-}
-
-func TestStrikeLightningWithoutLightningFactoryDoesNotPanic(t *testing.T) {
-	w := Config{Synchronous: true}.New()
-	defer w.Close()
-
-	<-w.Exec(func(tx *Tx) {
-		tx.World().set.Lock()
-		tx.World().set.Raining = true
-		tx.World().set.Thundering = true
-		tx.World().set.Unlock()
-		tx.World().chunk(ChunkPos{})
-		defer func() {
-			if r := recover(); r != nil {
-				t.Fatalf("strikeLightning panicked: %v", r)
-			}
-		}()
-		weather{w: tx.World()}.strikeLightning(tx, ChunkPos{})
-	})
 }
 
 type testEntityConfig struct{}

--- a/server/world/world_test.go
+++ b/server/world/world_test.go
@@ -93,28 +93,6 @@ func TestSynchronousAdvanceTickTicksViewerlessEntities(t *testing.T) {
 	}
 }
 
-func TestSynchronousAdvanceTickTicksViewerlessBlockEntities(t *testing.T) {
-	w := Config{Synchronous: true}.New()
-	defer w.Close()
-
-	pos := cube.Pos{0, 4, 0}
-	tb := &testTickerBlock{}
-	<-w.Exec(func(tx *Tx) {
-		col := tx.World().chunk(chunkPosFromBlockPos(pos))
-		chest, ok := tx.World().conf.Blocks.BlockByName("minecraft:chest", map[string]any{"minecraft:cardinal_direction": "north"})
-		if !ok {
-			t.Fatal("expected chest block to be registered")
-		}
-		col.SetBlock(uint8(pos[0]), int16(pos[1]), uint8(pos[2]), 0, tx.World().conf.Blocks.BlockRuntimeID(chest))
-		col.BlockEntities[pos] = tb
-	})
-
-	w.AdvanceTick()
-	if tb.ticks == 0 {
-		t.Fatal("expected block entity to tick")
-	}
-}
-
 type testEntityConfig struct{}
 
 func (testEntityConfig) Apply(*EntityData) {}
@@ -162,32 +140,4 @@ func (e *testEntity) Rotation() cube.Rotation {
 
 func (e *testEntity) Tick(*Tx, int64) {
 	e.data.Pos = e.data.Pos.Add(mgl64.Vec3{0, -0.1, 0})
-}
-
-type testTickerBlock struct {
-	ticks int
-}
-
-func (*testTickerBlock) EncodeBlock() (string, map[string]any) {
-	return "dragonfly:test_ticker", nil
-}
-
-func (*testTickerBlock) Hash() (uint64, uint64) {
-	return 1<<32 - 1, 0
-}
-
-func (*testTickerBlock) Model() BlockModel {
-	return unknownModel{}
-}
-
-func (*testTickerBlock) DecodeNBT(map[string]any) any {
-	return &testTickerBlock{}
-}
-
-func (*testTickerBlock) EncodeNBT() map[string]any {
-	return nil
-}
-
-func (b *testTickerBlock) Tick(int64, cube.Pos, *Tx) {
-	b.ticks++
 }

--- a/server/world/world_test.go
+++ b/server/world/world_test.go
@@ -93,6 +93,28 @@ func TestSynchronousAdvanceTickTicksViewerlessEntities(t *testing.T) {
 	}
 }
 
+func TestSynchronousAdvanceTickTicksViewerlessBlockEntities(t *testing.T) {
+	w := Config{Synchronous: true}.New()
+	defer w.Close()
+
+	pos := cube.Pos{0, 4, 0}
+	tb := &testTickerBlock{}
+	<-w.Exec(func(tx *Tx) {
+		col := tx.World().chunk(chunkPosFromBlockPos(pos))
+		chest, ok := tx.World().conf.Blocks.BlockByName("minecraft:chest", map[string]any{"minecraft:cardinal_direction": "north"})
+		if !ok {
+			t.Fatal("expected chest block to be registered")
+		}
+		col.SetBlock(uint8(pos[0]), int16(pos[1]), uint8(pos[2]), 0, tx.World().conf.Blocks.BlockRuntimeID(chest))
+		col.BlockEntities[pos] = tb
+	})
+
+	w.AdvanceTick()
+	if tb.ticks == 0 {
+		t.Fatal("expected block entity to tick")
+	}
+}
+
 type testEntityConfig struct{}
 
 func (testEntityConfig) Apply(*EntityData) {}
@@ -140,4 +162,32 @@ func (e *testEntity) Rotation() cube.Rotation {
 
 func (e *testEntity) Tick(*Tx, int64) {
 	e.data.Pos = e.data.Pos.Add(mgl64.Vec3{0, -0.1, 0})
+}
+
+type testTickerBlock struct {
+	ticks int
+}
+
+func (*testTickerBlock) EncodeBlock() (string, map[string]any) {
+	return "dragonfly:test_ticker", nil
+}
+
+func (*testTickerBlock) Hash() (uint64, uint64) {
+	return 1<<32 - 1, 0
+}
+
+func (*testTickerBlock) Model() BlockModel {
+	return unknownModel{}
+}
+
+func (*testTickerBlock) DecodeNBT(map[string]any) any {
+	return &testTickerBlock{}
+}
+
+func (*testTickerBlock) EncodeNBT() map[string]any {
+	return nil
+}
+
+func (b *testTickerBlock) Tick(int64, cube.Pos, *Tx) {
+	b.ticks++
 }

--- a/server/world/world_test.go
+++ b/server/world/world_test.go
@@ -1,24 +1,12 @@
 package world
 
 import (
-	"runtime"
 	"testing"
 	"time"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/go-gl/mathgl/mgl64"
 )
-
-// TestSynchronousWorldNoGoroutines verifies that a synchronous World starts no
-// background goroutines.
-func TestSynchronousWorldNoGoroutines(t *testing.T) {
-	before := runtime.NumGoroutine()
-	w := Config{Synchronous: true}.New()
-	if after := runtime.NumGoroutine(); after != before {
-		t.Errorf("expected no new goroutines after New(), had %v, got %v", before, after)
-	}
-	_ = w.Close()
-}
 
 // TestSynchronousWorldExec verifies that Exec on a synchronous World runs the
 // transaction on the calling goroutine, with the returned channel closed once

--- a/server/world/world_test.go
+++ b/server/world/world_test.go
@@ -1,0 +1,79 @@
+package world
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestSynchronousWorldNoGoroutines verifies that a synchronous World starts no
+// background goroutines.
+func TestSynchronousWorldNoGoroutines(t *testing.T) {
+	before := runtime.NumGoroutine()
+	w := Config{Synchronous: true}.New()
+	if after := runtime.NumGoroutine(); after != before {
+		t.Errorf("expected no new goroutines after New(), had %v, got %v", before, after)
+	}
+	_ = w.Close()
+}
+
+// TestSynchronousWorldExec verifies that Exec on a synchronous World runs the
+// transaction on the calling goroutine, with the returned channel closed once
+// Exec returns.
+func TestSynchronousWorldExec(t *testing.T) {
+	w := Config{Synchronous: true}.New()
+	defer w.Close()
+
+	var ran bool
+	c := w.Exec(func(tx *Tx) { ran = true })
+	if !ran {
+		t.Fatal("expected transaction to have run when Exec returned")
+	}
+	select {
+	case <-c:
+	default:
+		t.Fatal("expected channel returned by Exec to be closed when Exec returned")
+	}
+}
+
+// TestSynchronousWorldAdvanceTick verifies that a synchronous World does not
+// tick on its own and that AdvanceTick advances the current tick exactly once
+// per call, even without any viewers.
+func TestSynchronousWorldAdvanceTick(t *testing.T) {
+	w := Config{Synchronous: true}.New()
+	defer w.Close()
+
+	current := func() int64 {
+		w.set.Lock()
+		defer w.set.Unlock()
+		return w.set.CurrentTick
+	}
+	start := current()
+	time.Sleep(time.Second / 10)
+	if got := current(); got != start {
+		t.Fatalf("expected no automatic ticking, tick advanced from %v to %v", start, got)
+	}
+	for range 5 {
+		w.AdvanceTick()
+	}
+	if got := current(); got != start+5 {
+		t.Fatalf("expected current tick %v after 5 AdvanceTick calls, got %v", start+5, got)
+	}
+}
+
+// TestSynchronousWorldClose verifies that closing a synchronous World returns
+// promptly instead of waiting for goroutines that were never started.
+func TestSynchronousWorldClose(t *testing.T) {
+	w := Config{Synchronous: true}.New()
+
+	done := make(chan struct{})
+	go func() {
+		_ = w.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second * 5):
+		t.Fatal("Close did not return within 5 seconds")
+	}
+}

--- a/server/world/world_test.go
+++ b/server/world/world_test.go
@@ -4,6 +4,9 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/go-gl/mathgl/mgl64"
 )
 
 // TestSynchronousWorldNoGoroutines verifies that a synchronous World starts no
@@ -76,4 +79,163 @@ func TestSynchronousWorldClose(t *testing.T) {
 	case <-time.After(time.Second * 5):
 		t.Fatal("Close did not return within 5 seconds")
 	}
+}
+
+func TestSynchronousExecWorldCanRemoveEntity(t *testing.T) {
+	w := Config{Synchronous: true}.New()
+	defer w.Close()
+
+	h := EntitySpawnOpts{Position: mgl64.Vec3{0, 4, 0}}.New(testEntityType{}, testEntityConfig{})
+	<-w.Exec(func(tx *Tx) {
+		tx.AddEntity(h)
+	})
+
+	done := make(chan struct{})
+	go func() {
+		h.ExecWorld(func(tx *Tx, e Entity) {
+			tx.RemoveEntity(e)
+		})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second * 5):
+		t.Fatal("ExecWorld self-removal did not complete")
+	}
+}
+
+func TestSynchronousAdvanceTickTicksViewerlessEntities(t *testing.T) {
+	w := Config{Synchronous: true}.New()
+	defer w.Close()
+
+	h := EntitySpawnOpts{Position: mgl64.Vec3{0, 4, 0}}.New(testEntityType{}, testEntityConfig{})
+	<-w.Exec(func(tx *Tx) {
+		tx.AddEntity(h)
+	})
+
+	start := h.data.Pos
+	for range 3 {
+		w.AdvanceTick()
+	}
+	if got := h.data.Pos; got == start {
+		t.Fatalf("expected entity position to change after ticking, got %v", got)
+	}
+}
+
+func TestSynchronousAdvanceTickTicksViewerlessBlockEntities(t *testing.T) {
+	w := Config{Synchronous: true}.New()
+	defer w.Close()
+
+	pos := cube.Pos{0, 4, 0}
+	tb := &testTickerBlock{}
+	<-w.Exec(func(tx *Tx) {
+		col := tx.World().chunk(chunkPosFromBlockPos(pos))
+		chest, ok := tx.World().conf.Blocks.BlockByName("minecraft:chest", map[string]any{"minecraft:cardinal_direction": "north"})
+		if !ok {
+			t.Fatal("expected chest block to be registered")
+		}
+		col.SetBlock(uint8(pos[0]), int16(pos[1]), uint8(pos[2]), 0, tx.World().conf.Blocks.BlockRuntimeID(chest))
+		col.BlockEntities[pos] = tb
+	})
+
+	w.AdvanceTick()
+	if tb.ticks == 0 {
+		t.Fatal("expected block entity to tick")
+	}
+}
+
+func TestStrikeLightningWithoutLightningFactoryDoesNotPanic(t *testing.T) {
+	w := Config{Synchronous: true}.New()
+	defer w.Close()
+
+	<-w.Exec(func(tx *Tx) {
+		tx.World().set.Lock()
+		tx.World().set.Raining = true
+		tx.World().set.Thundering = true
+		tx.World().set.Unlock()
+		tx.World().chunk(ChunkPos{})
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("strikeLightning panicked: %v", r)
+			}
+		}()
+		weather{w: tx.World()}.strikeLightning(tx, ChunkPos{})
+	})
+}
+
+type testEntityConfig struct{}
+
+func (testEntityConfig) Apply(*EntityData) {}
+
+type testEntityType struct{}
+
+func (testEntityType) Open(_ *Tx, handle *EntityHandle, data *EntityData) Entity {
+	return &testEntity{handle: handle, data: data}
+}
+
+func (testEntityType) EncodeEntity() string {
+	return "dragonfly:test_entity"
+}
+
+func (testEntityType) BBox(Entity) cube.BBox {
+	return cube.Box(0, 0, 0, 1, 1, 1)
+}
+
+func (testEntityType) DecodeNBT(map[string]any, *EntityData) {}
+
+func (testEntityType) EncodeNBT(*EntityData) map[string]any {
+	return nil
+}
+
+type testEntity struct {
+	handle *EntityHandle
+	data   *EntityData
+}
+
+func (e *testEntity) Close() error {
+	return nil
+}
+
+func (e *testEntity) H() *EntityHandle {
+	return e.handle
+}
+
+func (e *testEntity) Position() mgl64.Vec3 {
+	return e.data.Pos
+}
+
+func (e *testEntity) Rotation() cube.Rotation {
+	return e.data.Rot
+}
+
+func (e *testEntity) Tick(*Tx, int64) {
+	e.data.Pos = e.data.Pos.Add(mgl64.Vec3{0, -0.1, 0})
+}
+
+type testTickerBlock struct {
+	ticks int
+}
+
+func (*testTickerBlock) EncodeBlock() (string, map[string]any) {
+	return "dragonfly:test_ticker", nil
+}
+
+func (*testTickerBlock) Hash() (uint64, uint64) {
+	return 1<<32 - 1, 0
+}
+
+func (*testTickerBlock) Model() BlockModel {
+	return unknownModel{}
+}
+
+func (*testTickerBlock) DecodeNBT(map[string]any) any {
+	return &testTickerBlock{}
+}
+
+func (*testTickerBlock) EncodeNBT() map[string]any {
+	return nil
+}
+
+func (b *testTickerBlock) Tick(int64, cube.Pos, *Tx) {
+	b.ticks++
 }


### PR DESCRIPTION
## Synchronous worlds

This PR adds `world.Config.Synchronous`. A synchronous `World` starts no background goroutines: transactions created through `World.Exec` are executed directly on the calling goroutine, the world is not saved automatically, unused chunks are not unloaded automatically, and no automatic ticking happens. Time only passes through the new `World.AdvanceTick` method, which runs exactly one tick synchronously.

## Why

Block, item and entity behaviour is currently very hard to unit test: constructing a `World` spins up a tick loop, autosave and transaction goroutines, and anything time-dependent (neighbour updates, scheduled ticks, random ticks) fires asynchronously at 20 TPS. As a result, `server/world` and `server/block` had no tests at all. A synchronous world is fully deterministic — set up state in one `Exec`, advance ticks explicitly, and assert the outcome, all in-process:

```go
w := world.Config{Synchronous: true, Entities: entity.DefaultRegistry}.New()
defer w.Close()

<-w.Exec(func(tx *world.Tx) {
    tx.SetBlock(support, block.Stone{}, nil)
    tx.SetBlock(torch, block.Torch{Facing: cube.FaceDown}, nil)
    tx.SetBlock(support, block.Air{}, nil)
})
w.AdvanceTick() // neighbour update fires deterministically here
```

`TestTorchBreaksWithoutSupport` (included) uses exactly this pattern; the other new tests cover the mode's contract (no goroutines started, inline `Exec`, no automatic ticking, prompt `Close`).

## Implementation notes

- `Exec` reuses `normalTransaction.Run` inline. `weakExec` runs the weak transaction body inline but skips the `cond.L`/`Broadcast` handshake: that handshake exists to wake a goroutine already waiting on `cond`, and in the inline case the caller only inspects the buffered channel after `weakExec` returns (taking `cond.L` inline would self-deadlock, as the caller in `EntityHandle` still holds it).
- `ticker.tick`'s "skip when no viewers" guard is bypassed for synchronous worlds, since their ticks only ever happen explicitly via `AdvanceTick`.
- Entities and viewers work unchanged; they simply don't advance between `AdvanceTick` calls.
