### PR TITLE
Add owner-safe scheduling APIs replacing public blocking transactions

### DIFF
--- a/server/block/block_behaviour_test.go
+++ b/server/block/block_behaviour_test.go
@@ -1,6 +1,7 @@
 package block_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/df-mc/dragonfly/server/block"
@@ -17,16 +18,20 @@ func TestTorchBreaksWithoutSupport(t *testing.T) {
 	defer w.Close()
 
 	support, torch := cube.Pos{0, 0, 0}, cube.Pos{0, 1, 0}
-	<-w.Exec(func(tx *world.Tx) {
+	w.Do(func(tx *world.Context) {
 		tx.SetBlock(support, block.Stone{}, nil)
 		tx.SetBlock(torch, block.Torch{Facing: cube.FaceDown}, nil)
 		tx.SetBlock(support, block.Air{}, nil)
 	})
 	w.AdvanceTick()
 
-	<-w.Exec(func(tx *world.Tx) {
-		if b := tx.Block(torch); b != (block.Air{}) {
-			t.Errorf("expected torch to break after removing its support, got %v", b)
-		}
+	b, err := world.Call(context.Background(), w, func(tx *world.Context) (world.Block, error) {
+		return tx.Block(torch), nil
 	})
+	if err != nil {
+		t.Fatalf("read torch block: %v", err)
+	}
+	if b != (block.Air{}) {
+		t.Errorf("expected torch to break after removing its support, got %v", b)
+	}
 }

--- a/server/block/block_behaviour_test.go
+++ b/server/block/block_behaviour_test.go
@@ -18,14 +18,14 @@ func TestTorchBreaksWithoutSupport(t *testing.T) {
 	defer w.Close()
 
 	support, torch := cube.Pos{0, 0, 0}, cube.Pos{0, 1, 0}
-	w.Do(func(tx *world.Context) {
+	w.Do(func(tx *world.Tx) {
 		tx.SetBlock(support, block.Stone{}, nil)
 		tx.SetBlock(torch, block.Torch{Facing: cube.FaceDown}, nil)
 		tx.SetBlock(support, block.Air{}, nil)
 	})
 	w.AdvanceTick()
 
-	b, err := world.Call(context.Background(), w, func(tx *world.Context) (world.Block, error) {
+	b, err := world.Call(context.Background(), w, func(tx *world.Tx) (world.Block, error) {
 		return tx.Block(torch), nil
 	})
 	if err != nil {

--- a/server/block/explosion.go
+++ b/server/block/explosion.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/cube/trace"
-	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/particle"
@@ -134,7 +133,7 @@ func (c ExplosionConfig) Explode(tx *world.Tx, explosionPos mgl64.Vec3) {
 		}
 	}
 
-	ctx := event.C(tx)
+	ctx := tx.Event()
 	spawnFire := c.SpawnFire
 	itemDropChance := c.ItemDropChance
 	if tx.World().Handler().HandleExplosion(ctx, explosionPos, &affectedEntities, &affectedBlocks, &itemDropChance, &spawnFire); ctx.Cancelled() {

--- a/server/block/farmland.go
+++ b/server/block/farmland.go
@@ -4,7 +4,6 @@ import (
 	"math/rand/v2"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/world"
 )
 
@@ -74,7 +73,7 @@ func (f Farmland) hydrated(pos cube.Pos, tx *world.Tx) bool {
 func (f Farmland) EntityLand(pos cube.Pos, tx *world.Tx, e world.Entity, _ *float64) {
 	if living, ok := e.(livingEntity); ok {
 		if fall, ok := living.(fallDistanceEntity); ok && rand.Float64() < fall.FallDistance()-0.5 {
-			ctx := event.C(tx)
+			ctx := tx.Event()
 			if tx.World().Handler().HandleCropTrample(ctx, pos); !ctx.Cancelled() {
 				tx.SetBlock(pos, Dirt{}, nil)
 			}

--- a/server/block/fire.go
+++ b/server/block/fire.go
@@ -4,7 +4,6 @@ package block
 
 import (
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/item/enchantment"
 	"github.com/df-mc/dragonfly/server/world"
@@ -175,12 +174,12 @@ func (f Fire) tick(pos cube.Pos, tx *world.Tx, r *rand.Rand) {
 // this might end up not happening.
 func (f Fire) spread(from, to cube.Pos, tx *world.Tx, r *rand.Rand) {
 	if _, air := tx.Block(to).(Air); !air {
-		ctx := event.C(tx)
+		ctx := tx.Event()
 		if tx.World().Handler().HandleBlockBurn(ctx, to); ctx.Cancelled() {
 			return
 		}
 	}
-	ctx := event.C(tx)
+	ctx := tx.Event()
 	if tx.World().Handler().HandleFireSpread(ctx, from, to); ctx.Cancelled() {
 		return
 	}

--- a/server/block/lava.go
+++ b/server/block/lava.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/sound"
 )
@@ -177,7 +176,7 @@ func (l Lava) Harden(pos cube.Pos, tx *world.Tx, flownIntoBy *cube.Pos) bool {
 			}
 		}, tx.Range())
 		if b != nil {
-			ctx := event.C(tx)
+			ctx := tx.Event()
 			if tx.World().Handler().HandleLiquidHarden(ctx, pos, l, water, b); ctx.Cancelled() {
 				return false
 			}
@@ -197,7 +196,7 @@ func (l Lava) Harden(pos cube.Pos, tx *world.Tx, flownIntoBy *cube.Pos) bool {
 	} else {
 		b = Cobblestone{}
 	}
-	ctx := event.C(tx)
+	ctx := tx.Event()
 	if tx.World().Handler().HandleLiquidHarden(ctx, pos, l, water, b); ctx.Cancelled() {
 		return false
 	}

--- a/server/block/leaves.go
+++ b/server/block/leaves.go
@@ -4,7 +4,6 @@ import (
 	"math/rand/v2"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
@@ -68,7 +67,7 @@ func (l Leaves) RandomTick(pos cube.Pos, tx *world.Tx, _ *rand.Rand) {
 			tx.SetBlock(pos, l, nil)
 			return
 		}
-		ctx := event.C(tx)
+		ctx := tx.Event()
 		if tx.World().Handler().HandleLeavesDecay(ctx, pos); ctx.Cancelled() {
 			// Prevent immediate re-updating.
 			l.ShouldUpdate = false

--- a/server/block/liquid.go
+++ b/server/block/liquid.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/world"
 )
 
@@ -42,7 +41,7 @@ func tickLiquid(b world.Liquid, pos cube.Pos, tx *world.Tx) {
 		if b.LiquidDepth()-4 > 0 {
 			res = b.WithDepth(b.LiquidDepth()-2*b.SpreadDecay(), false)
 		}
-		ctx := event.C(tx)
+		ctx := tx.Event()
 		if tx.World().Handler().HandleLiquidDecay(ctx, pos, b, res); ctx.Cancelled() {
 			return
 		}
@@ -138,7 +137,7 @@ func flowInto(b world.Liquid, src, pos cube.Pos, tx *world.Tx, falling bool) boo
 			// (basically considered full depth), so no need to continue.
 			return true
 		}
-		ctx := event.C(tx)
+		ctx := tx.Event()
 		if tx.World().Handler().HandleLiquidFlow(ctx, src, pos, b.WithDepth(newDepth, falling), existing); ctx.Cancelled() {
 			return false
 		}
@@ -160,7 +159,7 @@ func flowInto(b world.Liquid, src, pos cube.Pos, tx *world.Tx, falling bool) boo
 		// Can't flow into this block.
 		return false
 	}
-	ctx := event.C(tx)
+	ctx := tx.Event()
 	if tx.World().Handler().HandleLiquidFlow(ctx, src, pos, b.WithDepth(newDepth, falling), existing); ctx.Cancelled() {
 		return false
 	}

--- a/server/block/redstone.go
+++ b/server/block/redstone.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/model"
-	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/world"
 )
 
@@ -124,7 +123,7 @@ func updateRedstoneFrom(pos, source cube.Pos, tx *world.Tx) {
 
 // redstoneUpdateCancelled checks if the redstone update has been cancelled by the HandleRedstoneUpdate handler.
 func redstoneUpdateCancelled(pos cube.Pos, tx *world.Tx) bool {
-	ctx := event.C(tx)
+	ctx := tx.Event()
 	tx.World().Handler().HandleRedstoneUpdate(ctx, pos)
 	return ctx.Cancelled()
 }

--- a/server/block/water.go
+++ b/server/block/water.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/item/potion"
 	"github.com/df-mc/dragonfly/server/world"
@@ -126,7 +125,7 @@ func (w Water) ScheduledTick(pos cube.Pos, tx *world.Tx, _ *rand.Rand) {
 				// Only form a new source block if there either is no water below this block, or if the water
 				// below this is not falling (full source block).
 				res := Water{Depth: 8, Still: true}
-				ctx := event.C(tx)
+				ctx := tx.Event()
 				if tx.World().Handler().HandleLiquidFlow(ctx, pos, pos, res, w); ctx.Cancelled() {
 					return
 				}
@@ -158,7 +157,7 @@ func (w Water) Harden(pos cube.Pos, tx *world.Tx, flownIntoBy *cube.Pos) bool {
 		return false
 	}
 	if lava, ok := tx.Block(pos.Side(cube.FaceUp)).(Lava); ok {
-		ctx := event.C(tx)
+		ctx := tx.Event()
 		if tx.World().Handler().HandleLiquidHarden(ctx, pos, w, lava, Stone{}); ctx.Cancelled() {
 			return false
 		}
@@ -166,7 +165,7 @@ func (w Water) Harden(pos cube.Pos, tx *world.Tx, flownIntoBy *cube.Pos) bool {
 		tx.PlaySound(pos.Vec3Centre(), sound.Fizz{})
 		return true
 	} else if lava, ok := tx.Block(*flownIntoBy).(Lava); ok {
-		ctx := event.C(tx)
+		ctx := tx.Event()
 		if tx.World().Handler().HandleLiquidHarden(ctx, pos, w, lava, Cobblestone{}); ctx.Cancelled() {
 			return false
 		}

--- a/server/cmd/argument.go
+++ b/server/cmd/argument.go
@@ -275,6 +275,9 @@ func (p parser) parseTargets(line *Line, tx *world.Tx) ([]Target, error) {
 	if !ok {
 		return nil, line.UsageError()
 	}
+	if strings.HasPrefix(first, "@") && tx == nil {
+		return nil, MessageNoTargets.F()
+	}
 	switch first[:min(len(first), 2)] {
 	case "@p":
 		pos := line.src.Position()

--- a/server/cmd/command.go
+++ b/server/cmd/command.go
@@ -31,7 +31,8 @@ import (
 type Runnable interface {
 	// Run runs the Command, using the arguments passed to the Command. The source is passed to the method,
 	// which is the source of the Command execution, and the output is passed, to which messages may be
-	// added which get sent to the source.
+	// added which get sent to the source. tx is nil for sources not attached to
+	// a world, such as a console source. Runnables that use tx must nil-check it.
 	Run(src Source, o *Output, tx *world.Tx)
 }
 
@@ -123,8 +124,9 @@ func (cmd Command) Aliases() []string {
 // If parsing of all Runnables was unsuccessful, a command output with an error message is sent to the Source
 // passed, and the Run method of the Runnables are not called.
 // The Source passed must not be nil. The method will panic if a nil Source is passed.
-// tx may be nil for sources that are not attached to a world, provided the command does not parse target
-// selector parameters or otherwise require owner-scoped world access.
+// tx may be nil for sources that are not attached to a world. Selector parsing
+// reports an error when it requires a transaction; Runnable bodies must
+// independently nil-check tx before using it.
 func (cmd Command) Execute(args string, source Source, tx *world.Tx) {
 	if source == nil {
 		panic("execute: invalid command source: source must not be nil")

--- a/server/cmd/command.go
+++ b/server/cmd/command.go
@@ -123,6 +123,8 @@ func (cmd Command) Aliases() []string {
 // If parsing of all Runnables was unsuccessful, a command output with an error message is sent to the Source
 // passed, and the Run method of the Runnables are not called.
 // The Source passed must not be nil. The method will panic if a nil Source is passed.
+// tx may be nil for sources that are not attached to a world, provided the command does not parse target
+// selector parameters or otherwise require owner-scoped world access.
 func (cmd Command) Execute(args string, source Source, tx *world.Tx) {
 	if source == nil {
 		panic("execute: invalid command source: source must not be nil")

--- a/server/cmd/target.go
+++ b/server/cmd/target.go
@@ -23,6 +23,9 @@ type NamedTarget interface {
 
 // targets returns all Targets selectable by the Source passed.
 func targets(tx *world.Tx) (entities []Target, players []NamedTarget) {
+	if tx == nil {
+		return nil, nil
+	}
 	ent := sliceutil.Convert[Target](slices.Collect(tx.Entities()))
 	pl := sliceutil.Convert[NamedTarget](slices.Collect(tx.Players()))
 	return ent, pl

--- a/server/item/goat_horn.go
+++ b/server/item/goat_horn.go
@@ -28,9 +28,7 @@ func (GoatHorn) Cooldown() time.Duration {
 // Use ...
 func (g GoatHorn) Use(tx *world.Tx, user User, _ *UseContext) bool {
 	tx.PlaySound(user.Position(), sound.GoatHorn{Horn: g.Type})
-	time.AfterFunc(time.Second, func() {
-		user.H().ExecWorld(g.releaseItem)
-	})
+	user.H().DoAfter(time.Second, g.releaseItem)
 	return true
 }
 

--- a/server/player/context.go
+++ b/server/player/context.go
@@ -1,0 +1,36 @@
+package player
+
+import (
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+// Context is the context passed to player event callbacks. It embeds the
+// world Context, so world operations and Cancel are available directly, and
+// adds the Player the event concerns. It is valid only during the callback.
+type Context struct {
+	*world.Context
+	p *Player
+}
+
+// newContext returns a Context for one event dispatch concerning p.
+func newContext(p *Player) *Context {
+	return &Context{Context: p.tx.Event(), p: p}
+}
+
+// Player returns the player the event concerns, valid only during the
+// callback.
+func (ctx *Context) Player() *Player { return ctx.p }
+
+// Defer schedules f to run on the owner after the current callback completes,
+// with the player re-resolved for that moment. If the player left the world by
+// then, the task fails with world.ErrEntityClosed.
+func (ctx *Context) Defer(f func(ctx *Context)) *world.Task {
+	h := ctx.p.H()
+	return ctx.DeferErr(func(wctx *world.Context) error {
+		if e, ok := h.Entity(wctx); ok {
+			f(newContext(e.(*Player)))
+			return nil
+		}
+		return world.ErrEntityClosed
+	})
+}

--- a/server/player/context.go
+++ b/server/player/context.go
@@ -22,15 +22,26 @@ func newContext(p *Player) *Context {
 func (ctx *Context) Player() *Player { return ctx.p }
 
 // Defer schedules f to run on the owner after the current callback completes,
-// with the player re-resolved for that moment. If the player left the world by
-// then, the task fails with world.ErrEntityClosed.
+// with the player re-resolved for that moment. The task fails with
+// world.ErrEntityClosed if the player's handle closed, or with
+// world.ErrEntityNotInWorld if the player left this transaction's world.
 func (ctx *Context) Defer(f func(ctx *Context)) *world.Task {
+	return ctx.DeferErr(func(ctx *Context) error {
+		f(ctx)
+		return nil
+	})
+}
+
+// DeferErr schedules f like Defer and records its returned error on the Task.
+func (ctx *Context) DeferErr(f func(ctx *Context) error) *world.Task {
 	h := ctx.p.H()
-	return ctx.DeferErr(func(wctx *world.Context) error {
-		if e, ok := h.Entity(wctx); ok {
-			f(newContext(e.(*Player)))
-			return nil
+	return ctx.Context.DeferErr(func(tx *world.Tx) error {
+		if e, ok := h.Entity(tx); ok {
+			return f(newContext(e.(*Player)))
 		}
-		return world.ErrEntityClosed
+		if h.Closed() {
+			return world.ErrEntityClosed
+		}
+		return world.ErrEntityNotInWorld
 	})
 }

--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -6,15 +6,12 @@ import (
 
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/cmd"
-	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/player/skin"
 	"github.com/df-mc/dragonfly/server/session"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
 )
-
-type Context = event.Context[*Player]
 
 // Handler handles events that are called by a player. Implementations of Handler may be used to listen to
 // specific events such as when a player chats or moves.

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -356,7 +356,7 @@ func (p *Player) ExecuteCommand(commandLine string) {
 	if p.Handler().HandleCommandExecution(ctx, command, args[1:]); ctx.Cancelled() {
 		return
 	}
-	command.Execute(strings.Join(args[1:], " "), p, p.tx.Event())
+	command.Execute(strings.Join(args[1:], " "), p, p.tx)
 }
 
 // Transfer transfers the player to a server at the address passed. If the address could not be resolved, an
@@ -878,7 +878,7 @@ func (p *Player) kill(src world.DamageSource) {
 
 	// Wait a little before removing the entity. The client displays a death
 	// animation while the player is dying.
-	NewRef(p.handle).DoAfter(time.Millisecond*1100, func(_ *world.Tx, p *Player) {
+	DoAfter(p.handle, time.Millisecond*1100, func(_ *world.Tx, p *Player) {
 		finishDying(p)
 	})
 }

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1,6 +1,7 @@
 package player
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/rand/v2"
@@ -196,7 +197,7 @@ func (p *Player) Skin() skin.Skin {
 // SetSkin changes the skin of the player. This skin will be visible to other players that the player
 // is shown to.
 func (p *Player) SetSkin(skin skin.Skin) {
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleSkinChange(ctx, &skin); ctx.Cancelled() {
 		p.session().ViewSkin(p)
 		return
@@ -323,7 +324,7 @@ func (p *Player) RemoveBossBar() {
 // player and is formatted following the rules of fmt.Sprintln.
 func (p *Player) Chat(msg ...any) {
 	message := format(msg)
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleChat(ctx, &message); ctx.Cancelled() {
 		return
 	}
@@ -351,11 +352,11 @@ func (p *Player) ExecuteCommand(commandLine string) {
 		p.SendCommandOutput(o)
 		return
 	}
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleCommandExecution(ctx, command, args[1:]); ctx.Cancelled() {
 		return
 	}
-	command.Execute(strings.Join(args[1:], " "), p, p.tx)
+	command.Execute(strings.Join(args[1:], " "), p, p.tx.Event())
 }
 
 // Transfer transfers the player to a server at the address passed. If the address could not be resolved, an
@@ -366,7 +367,7 @@ func (p *Player) Transfer(address string) error {
 		return err
 	}
 
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleTransfer(ctx, addr); ctx.Cancelled() {
 		return nil
 	}
@@ -528,7 +529,7 @@ func (p *Player) Heal(health float64, source world.HealingSource) {
 	if p.Dead() || health < 0 || !p.GameMode().AllowsTakingDamage() {
 		return
 	}
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleHeal(ctx, &health, source); ctx.Cancelled() {
 		return
 	}
@@ -595,7 +596,7 @@ func (p *Player) Hurt(dmg float64, src world.DamageSource) (float64, bool) {
 	}
 
 	immunity := time.Second / 2
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleHurt(ctx, &damageLeft, immune, &immunity, src); ctx.Cancelled() {
 		return 0, false
 	}
@@ -820,7 +821,7 @@ func (p *Player) Exhaust(points float64) {
 		// Temporarily set the food level back so that it hasn't yet changed once the event is handled.
 		p.hunger.SetFood(before)
 
-		ctx := event.C(p)
+		ctx := newContext(p)
 		if p.Handler().HandleFoodLoss(ctx, before, &after); ctx.Cancelled() {
 			// Reset the exhaustion level if the event was cancelled. Because if
 			// we cancel this, and at some point we stop cancelling it, the
@@ -877,14 +878,13 @@ func (p *Player) kill(src world.DamageSource) {
 
 	// Wait a little before removing the entity. The client displays a death
 	// animation while the player is dying.
-	time.AfterFunc(time.Millisecond*1100, func() {
-		p.H().ExecWorld(finishDying)
+	NewRef(p.handle).DoAfter(time.Millisecond*1100, func(_ *world.Tx, p *Player) {
+		finishDying(p)
 	})
 }
 
 // finishDying completes the death of a player, removing it from the world.
-func finishDying(_ *world.Tx, e world.Entity) {
-	p := e.(*Player)
+func finishDying(p *Player) {
 	if p.session() == session.Nop {
 		_ = p.Close()
 		return
@@ -944,6 +944,10 @@ func (p *Player) Respawn() *world.EntityHandle {
 	return p.handle
 }
 
+// respawn heals the player and moves it to its spawn position. f, if
+// non-nil, runs with the player once it is back in a world — normally the
+// respawn destination, otherwise the world it died in — so a quit callback
+// from close always completes the player's teardown.
 func (p *Player) respawn(f func(p *Player)) {
 	if !p.Dead() || p.session() == session.Nop {
 		return
@@ -964,8 +968,20 @@ func (p *Player) respawn(f func(p *Player)) {
 
 	p.Handler().HandleRespawn(p, &pos, &w)
 
+	sess := p.session()
+	src := p.tx.World()
 	handle := p.tx.RemoveEntity(p)
-	w.Exec(func(tx *world.Tx) {
+	// restore re-adds the player through tx and finishes with f or the normal
+	// quit path; the fallback branches below share it.
+	restore := func(tx *world.Tx) {
+		np := tx.AddEntity(handle).(*Player)
+		if f != nil {
+			f(np)
+			return
+		}
+		np.quit("respawn failed")
+	}
+	task := w.Do(func(tx *world.Tx) {
 		np := tx.AddEntity(handle).(*Player)
 		np.Teleport(pos)
 		np.session().SendRespawn(pos, p)
@@ -973,6 +989,32 @@ func (p *Player) respawn(f func(p *Player)) {
 		if f != nil {
 			f(np)
 		}
+	})
+	if errors.Is(task.Err(), world.ErrWorldClosed) {
+		// The destination refused synchronously: re-add through the still-open
+		// source context. This also keeps synchronous worlds fully inline.
+		restore(p.tx)
+		return
+	}
+	task.OnDone(func(err error) {
+		// Only ErrWorldClosed means the entity was never re-added. A callback
+		// panic is left alone: the entity is live.
+		if !errors.Is(err, world.ErrWorldClosed) {
+			return
+		}
+		// Fall back to the source world so the normal quit path still runs.
+		src.Do(restore).OnDone(func(err error) {
+			if err == nil || errors.Is(err, world.ErrTaskPanicked) {
+				return
+			}
+			// The source world is gone too; the handle is orphaned. Close the
+			// session without a world so the stop handler still runs, then
+			// free the connection.
+			_ = handle.Close()
+			sess.Disconnect("respawn failed")
+			sess.Close(nil, p)
+			sess.CloseConnection()
+		})
 	})
 }
 
@@ -1003,7 +1045,7 @@ func (p *Player) StartSprinting() {
 	if !p.hunger.canSprint() && p.GameMode().AllowsTakingDamage() || p.crawling || p.sprinting {
 		return
 	}
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleToggleSprint(ctx, true); ctx.Cancelled() {
 		return
 	}
@@ -1023,7 +1065,7 @@ func (p *Player) StopSprinting() {
 	if !p.sprinting {
 		return
 	}
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleToggleSprint(ctx, false); ctx.Cancelled() {
 		return
 	}
@@ -1039,7 +1081,7 @@ func (p *Player) StartSneaking() {
 	if p.sneaking {
 		return
 	}
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleToggleSneak(ctx, true); ctx.Cancelled() {
 		return
 	}
@@ -1061,7 +1103,7 @@ func (p *Player) StopSneaking() {
 	if !p.sneaking {
 		return
 	}
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleToggleSneak(ctx, false); ctx.Cancelled() {
 		return
 	}
@@ -1221,7 +1263,7 @@ func (p *Player) Sleep(pos cube.Pos) {
 		return
 	}
 
-	ctx, sendReminder := event.C(p), true
+	ctx, sendReminder := newContext(p), true
 	if p.Handler().HandleSleep(ctx, &sendReminder); ctx.Cancelled() {
 		return
 	}
@@ -1400,7 +1442,7 @@ func (p *Player) SetHeldSlot(to int) error {
 		return nil
 	}
 
-	ctx := event.C(p)
+	ctx := newContext(p)
 	p.Handler().HandleHeldSlotChange(ctx, from, to)
 	if ctx.Cancelled() {
 		// The slot change was cancelled, resend held slot.
@@ -1487,7 +1529,7 @@ func (p *Player) SetCooldown(item world.Item, cooldown time.Duration) {
 // This generally happens for items such as throwable items like snowballs.
 func (p *Player) UseItem() {
 	i, _ := p.HeldItems()
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.HasCooldown(i.Item()) {
 		return
 	}
@@ -1565,7 +1607,7 @@ func (p *Player) UseItem() {
 		}
 		// Reset the duration for the next item to be consumed.
 		p.usingSince = time.Now()
-		ctx := event.C(p)
+		ctx := newContext(p)
 		if p.Handler().HandleItemConsume(ctx, i); ctx.Cancelled() {
 			return
 		}
@@ -1589,7 +1631,7 @@ func (p *Player) ReleaseItem() {
 
 	useCtx, dur := p.useContext(), p.useDuration()
 	i, _ := p.HeldItems()
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleItemRelease(ctx, i, dur); ctx.Cancelled() {
 		return
 	}
@@ -1672,7 +1714,7 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 		p.resendNearbyBlocks(pos, face)
 		return
 	}
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleItemUseOnBlock(ctx, pos, face, clickPos); ctx.Cancelled() {
 		p.resendNearbyBlocks(pos, face)
 		return
@@ -1731,7 +1773,7 @@ func (p *Player) UseItemOnEntity(e world.Entity) bool {
 	if !p.canReach(e.Position()) {
 		return false
 	}
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleItemUseOnEntity(ctx, e); ctx.Cancelled() {
 		return false
 	}
@@ -1779,7 +1821,7 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 		height += inc
 	}
 
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleAttackEntity(ctx, e, &force, &height, &critical); ctx.Cancelled() {
 		return false
 	}
@@ -1847,7 +1889,7 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 		return
 	}
 	if _, ok := p.tx.Block(pos.Side(face)).(block.Fire); ok {
-		ctx := event.C(p)
+		ctx := newContext(p)
 		if p.Handler().HandleFireExtinguish(ctx, pos); ctx.Cancelled() {
 			// Resend the block because on client side that was extinguished
 			p.resendNearbyBlocks(pos, face)
@@ -1868,7 +1910,7 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	// can resend the block to the client when it tries to break the block regardless.
 	p.breakingPos = pos
 
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleStartBreak(ctx, pos); ctx.Cancelled() {
 		return
 	}
@@ -1995,7 +2037,7 @@ func (p *Player) placeBlock(pos cube.Pos, b world.Block, ignoreBBox bool) bool {
 		return false
 	}
 
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleBlockPlace(ctx, pos, b); ctx.Cancelled() {
 		p.resendNearbyBlocks(pos, cube.Faces()...)
 		return false
@@ -2062,7 +2104,7 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 		}
 	}
 
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleBlockBreak(ctx, pos, &drops, &xp); ctx.Cancelled() {
 		p.resendNearbyBlocks(pos)
 		return
@@ -2137,7 +2179,7 @@ func (p *Player) PickBlock(pos cube.Pos) {
 		return
 	}
 
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleBlockPick(ctx, pos, b); ctx.Cancelled() {
 		return
 	}
@@ -2169,7 +2211,7 @@ func (p *Player) PickBlock(pos cube.Pos) {
 // Teleport teleports the player to a target position in the world. Unlike Move, it immediately changes the
 // position of the player, rather than showing an animation.
 func (p *Player) Teleport(pos mgl64.Vec3) {
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleTeleport(ctx, pos); ctx.Cancelled() {
 		return
 	}
@@ -2207,7 +2249,7 @@ func (p *Player) Move(deltaPos mgl64.Vec3, deltaYaw, deltaPitch float64) {
 		pos         = p.Position()
 		res, resRot = pos.Add(deltaPos), p.Rotation().Add(cube.Rotation{deltaYaw, deltaPitch})
 	)
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleMove(ctx, res, resRot); ctx.Cancelled() {
 		if p.session() != session.Nop && pos.ApproxEqual(p.Position()) {
 			// The position of the player was changed and the event cancelled. This means we still need to notify the
@@ -2296,7 +2338,7 @@ func (p *Player) Collect(s item.Stack) (int, bool) {
 	if p.Dead() || !p.GameMode().AllowsInteraction() {
 		return 0, false
 	}
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleItemPickup(ctx, &s); ctx.Cancelled() {
 		return 0, false
 	}
@@ -2328,7 +2370,7 @@ func (p *Player) ResetEnchantmentSeed() {
 
 // AddExperience adds experience to the player.
 func (p *Player) AddExperience(amount int) int {
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleExperienceGain(ctx, &amount); ctx.Cancelled() {
 		return 0
 	}
@@ -2449,7 +2491,7 @@ func (p *Player) mendItems(xp int) int {
 // The number of items that was dropped in the end is returned. It is generally the count of the stack passed
 // or 0 if dropping the item.Stack was cancelled.
 func (p *Player) Drop(s item.Stack) int {
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleItemDrop(ctx, s); ctx.Cancelled() {
 		return 0
 	}
@@ -2957,7 +2999,7 @@ func (p *Player) EditSign(pos cube.Pos, frontText, backText string) error {
 		return nil
 	}
 
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if frontText != sign.Front.Text {
 		if p.Handler().HandleSignEdit(ctx, pos, true, sign.Front.Text, frontText); ctx.Cancelled() {
 			p.resendNearbyBlock(pos)
@@ -2985,7 +3027,7 @@ func (p *Player) TurnLecternPage(pos cube.Pos, page int) error {
 		return fmt.Errorf("edit lectern: no lectern at position %v", pos)
 	}
 
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleLecternPageTurn(ctx, pos, lectern.Page, &page); ctx.Cancelled() {
 		return nil
 	}
@@ -3027,7 +3069,7 @@ func (p *Player) PunchAir() {
 	if p.Dead() {
 		return
 	}
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandlePunchAir(ctx); ctx.Cancelled() {
 		return
 	}
@@ -3084,7 +3126,7 @@ func (p *Player) damageItem(s item.Stack, d int) item.Stack {
 	if p.GameMode().CreativeInventory() || d == 0 || s.MaxDurability() == -1 {
 		return s
 	}
-	ctx := event.C(p)
+	ctx := newContext(p)
 	if p.Handler().HandleItemDamage(ctx, s, &d); ctx.Cancelled() || d <= 0 {
 		return s
 	}
@@ -3137,6 +3179,9 @@ func (p *Player) canReach(pos mgl64.Vec3) bool {
 // Disconnect closes the player and removes it from the world.
 // Disconnect, unlike Close, allows a custom message to be passed to show to the player when it is
 // disconnected. The message is formatted following the rules of fmt.Sprintln without a newline at the end.
+// The player is removed from its current world before Disconnect returns and
+// must not be used afterwards. If the player is dead, it first respawns: the
+// remaining teardown completes on the owner of the world it respawns into.
 func (p *Player) Disconnect(msg ...any) {
 	p.once.Do(func() {
 		p.close(format(msg))
@@ -3146,6 +3191,9 @@ func (p *Player) Disconnect(msg ...any) {
 // Close closes the player and removes it from the world.
 // Close disconnects the player with a 'Connection closed.' message. Disconnect should be used to disconnect a
 // player with a custom message.
+// The player is removed from its current world before Close returns and must
+// not be used afterwards. If the player is dead, it first respawns: the
+// remaining teardown completes on the owner of the world it respawns into.
 func (p *Player) Close() error {
 	p.once.Do(func() {
 		p.close("Connection closed.")
@@ -3173,6 +3221,10 @@ func (p *Player) quit(msg string) {
 
 	if s := p.s; s != nil {
 		s.Disconnect(msg)
+		// Close the session on this owner directly: teardown must not depend
+		// on the session goroutine, which cannot schedule work anymore once
+		// the world starts closing.
+		s.Close(p.tx, p)
 		s.CloseConnection()
 		return
 	}

--- a/server/player/ref.go
+++ b/server/player/ref.go
@@ -1,0 +1,31 @@
+package player
+
+import (
+	"time"
+
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+// Ref is a stable reference to a player that outlives callbacks. The *Player
+// value is only handed to scheduled owner callbacks, where it is safe to use.
+type Ref = world.EntityRef[*Player]
+
+// NewRef creates a typed player reference from an entity handle.
+func NewRef(h *world.EntityHandle) Ref { return world.NewEntityRef[*Player](h) }
+
+// Do schedules f to run with the player on its current world owner. Use it to
+// re-enter the player from code that outlived a callback.
+func (p *Player) Do(f func(tx *world.Tx, p *Player)) *world.Task {
+	if p == nil {
+		return world.NewFinishedTask(world.ErrEntityClosed)
+	}
+	return NewRef(p.handle).Do(f)
+}
+
+// DoAfter schedules f on the player's current world owner after delay.
+func (p *Player) DoAfter(delay time.Duration, f func(tx *world.Tx, p *Player)) *world.Task {
+	if p == nil {
+		return world.NewFinishedTask(world.ErrEntityClosed)
+	}
+	return NewRef(p.handle).DoAfter(delay, f)
+}

--- a/server/player/ref.go
+++ b/server/player/ref.go
@@ -1,6 +1,7 @@
 package player
 
 import (
+	"context"
 	"time"
 
 	"github.com/df-mc/dragonfly/server/world"
@@ -13,13 +14,29 @@ type Ref = world.EntityRef[*Player]
 // NewRef creates a typed player reference from an entity handle.
 func NewRef(h *world.EntityHandle) Ref { return world.NewEntityRef[*Player](h) }
 
+// Do schedules f to run with the player identified by h on its current world owner.
+func Do(h *world.EntityHandle, f func(tx *world.Tx, p *Player)) *world.Task {
+	return NewRef(h).Do(f)
+}
+
+// DoAfter schedules f to run with the player identified by h after delay.
+func DoAfter(h *world.EntityHandle, delay time.Duration, f func(tx *world.Tx, p *Player)) *world.Task {
+	return NewRef(h).DoAfter(delay, f)
+}
+
+// Call runs f with the player identified by h on its current world owner and
+// waits for its typed result.
+func Call[T any](ctx context.Context, h *world.EntityHandle, f func(tx *world.Tx, p *Player) (T, error)) (T, error) {
+	return world.CallRef(ctx, NewRef(h), f)
+}
+
 // Do schedules f to run with the player on its current world owner. Use it to
 // re-enter the player from code that outlived a callback.
 func (p *Player) Do(f func(tx *world.Tx, p *Player)) *world.Task {
 	if p == nil {
 		return world.NewFinishedTask(world.ErrEntityClosed)
 	}
-	return NewRef(p.handle).Do(f)
+	return Do(p.handle, f)
 }
 
 // DoAfter schedules f on the player's current world owner after delay.
@@ -27,5 +44,5 @@ func (p *Player) DoAfter(delay time.Duration, f func(tx *world.Tx, p *Player)) *
 	if p == nil {
 		return world.NewFinishedTask(world.ErrEntityClosed)
 	}
-	return NewRef(p.handle).DoAfter(delay, f)
+	return DoAfter(p.handle, delay, f)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -115,10 +115,12 @@ func (srv *Server) Listen() {
 
 // Accept accepts incoming players into the server, returning an iterator that
 // yields players that join the server while blocking otherwise. The iterator
-// returned ends when the Server is closed using a call to Close. Players
-// returned are only valid within the block of the for loop used to iterate over
-// them. Use Player.H(), player.NewRef, or Player.Do when a player must
-// be referenced after the iterator callback returns:
+// returned ends when the Server is closed using a call to Close. The loop body
+// runs on the player's world owner: blocking there stalls that world, and
+// calling world.Call, world.CallEntity, world.CallRef, or Task.Wait for the
+// same owner deadlocks. Players returned are only valid within the block of the
+// for loop used to iterate over them. Use p.H() with player.Do for work that
+// outlives the loop body:
 //
 //	for p := range srv.Accept() {
 //	  // p is valid here
@@ -205,8 +207,14 @@ func (srv *Server) PlayerCount() int {
 
 // Players returns an iterator that yields players currently online. If Players
 // is called from within a transaction, the respective transaction should be
-// passed. Passing nil is otherwise valid. Players returned are only valid
-// within the block of the for loop used to iterate over them:
+// passed. Passing nil is otherwise valid. Each loop body runs on the yielded
+// player's world owner, so blocking stalls that world and calling world.Call,
+// world.CallEntity, world.CallRef, or Task.Wait for the same owner deadlocks.
+// Players in other worlds are yielded by blocking on those owners sequentially;
+// mirrored handlers in two worlds can therefore deadlock each other. For
+// fan-out, collect Player.H values and schedule each with player.Do instead.
+// Players returned are only valid within the block of the for loop used to
+// iterate over them:
 //
 //	for p := range srv.Players(nil) {
 //	  // p is valid here
@@ -218,7 +226,7 @@ func (srv *Server) PlayerCount() int {
 //
 // Collecting all values from the iterator using a function such as
 // slices.Collect immediately invalidates the players because their transactions
-// will be finished. Use Player.H(), player.NewRef, or Player.Do when a
+// will be finished. Use Player.H(), player.NewRef, or player.Do when a
 // player must be referenced after the iterator callback returns.
 func (srv *Server) Players(tx *world.Tx) iter.Seq[*player.Player] {
 	srv.pmu.RLock()
@@ -238,7 +246,7 @@ func (srv *Server) Players(tx *world.Tx) iter.Seq[*player.Player] {
 					continue
 				}
 			}
-			ret, err := world.CallRef(context.Background(), player.NewRef(handle), func(_ *world.Tx, p *player.Player) (bool, error) {
+			ret, err := player.Call(context.Background(), handle, func(_ *world.Tx, p *player.Player) (bool, error) {
 				return !yield(p), nil
 			})
 			if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -117,7 +117,8 @@ func (srv *Server) Listen() {
 // yields players that join the server while blocking otherwise. The iterator
 // returned ends when the Server is closed using a call to Close. Players
 // returned are only valid within the block of the for loop used to iterate over
-// them:
+// them. Use Player.H(), player.NewRef, or Player.Do when a player must
+// be referenced after the iterator callback returns:
 //
 //	for p := range srv.Accept() {
 //	  // p is valid here
@@ -137,12 +138,25 @@ func (srv *Server) Accept() iter.Seq[*player.Player] {
 			srv.p[inc.p.handle.UUID()] = inc.p
 			srv.pmu.Unlock()
 
-			ret := false
-			<-inc.w.Exec(func(tx *world.Tx) {
+			ret, err := world.Call(context.Background(), inc.w, func(tx *world.Tx) (bool, error) {
 				p := tx.AddEntity(inc.p.handle).(*player.Player)
 				inc.s.Spawn(p, tx)
-				ret = !yield(p)
+				return !yield(p), nil
 			})
+			if err != nil {
+				world.RethrowPanic(err)
+				srv.pmu.Lock()
+				delete(srv.p, inc.p.handle.UUID())
+				srv.pmu.Unlock()
+				srv.pwg.Done()
+				// Join failed before spawn: the entity was never added, so close
+				// the orphaned handle and fully tear the session down (Disconnect
+				// only writes a packet; CloseConnection frees the conn/goroutines).
+				_ = inc.p.handle.Close()
+				inc.s.Disconnect("join failed")
+				inc.s.CloseConnection()
+				continue
+			}
 			if ret {
 				return
 			}
@@ -204,7 +218,8 @@ func (srv *Server) PlayerCount() int {
 //
 // Collecting all values from the iterator using a function such as
 // slices.Collect immediately invalidates the players because their transactions
-// will be finished.
+// will be finished. Use Player.H(), player.NewRef, or Player.Do when a
+// player must be referenced after the iterator callback returns.
 func (srv *Server) Players(tx *world.Tx) iter.Seq[*player.Player] {
 	srv.pmu.RLock()
 	handles := make([]*world.EntityHandle, 0, len(srv.p))
@@ -223,10 +238,13 @@ func (srv *Server) Players(tx *world.Tx) iter.Seq[*player.Player] {
 					continue
 				}
 			}
-			ret := false
-			handle.ExecWorld(func(tx *world.Tx, e world.Entity) {
-				ret = !yield(e.(*player.Player))
+			ret, err := world.CallRef(context.Background(), player.NewRef(handle), func(_ *world.Tx, p *player.Player) (bool, error) {
+				return !yield(p), nil
 			})
+			if err != nil {
+				world.RethrowPanic(err)
+				continue
+			}
 			if ret {
 				break
 			}
@@ -514,8 +532,12 @@ func (srv *Server) handleSessionClose(tx *world.Tx, c session.Controllable) {
 		return
 	}
 
-	if err := srv.conf.PlayerProvider.Save(c.UUID(), c.(*player.Player).Data(), tx.World()); err != nil {
-		srv.conf.Log.Error("Save player data: " + err.Error())
+	if tx != nil {
+		if err := srv.conf.PlayerProvider.Save(c.UUID(), c.(*player.Player).Data(), tx.World()); err != nil {
+			srv.conf.Log.Error("Save player data: " + err.Error())
+		}
+	} else {
+		srv.conf.Log.Error("Save player data: player's worlds closed before teardown; data not saved", "uuid", c.UUID())
 	}
 	srv.pwg.Done()
 }

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -162,6 +162,9 @@ type Config struct {
 
 	JoinMessage, QuitMessage chat.Translation
 
+	// HandleStop is called once when the Session is closed. The transaction is
+	// nil if the Controllable could not be restored to any world, such as when
+	// both its current world and respawn destination closed during teardown.
 	HandleStop func(*world.Tx, Controllable)
 	// BlockRegistry overrides the registry used for network serialization. If nil, world.DefaultBlockRegistry is used.
 	BlockRegistry world.BlockRegistry
@@ -286,6 +289,9 @@ func (s *Session) Spawn(c Controllable, tx *world.Tx) {
 
 // Close closes the session, which in turn closes the controllable and the connection that the session
 // manages. Close ensures the method only runs code on the first call.
+// A nil transaction may be passed for a Controllable that is no longer in any
+// world; world-bound teardown (container close, chunk loader, entity removal)
+// is then skipped.
 func (s *Session) Close(tx *world.Tx, c Controllable) {
 	s.once.Do(func() {
 		s.close(tx, c)
@@ -295,8 +301,10 @@ func (s *Session) Close(tx *world.Tx, c Controllable) {
 // close closes the session, which in turn closes the controllable and the connection that the session
 // manages.
 func (s *Session) close(tx *world.Tx, c Controllable) {
-	c.MoveItemsToInventory()
-	s.closeCurrentContainer(tx, false)
+	if tx != nil {
+		c.MoveItemsToInventory()
+		s.closeCurrentContainer(tx, false)
+	}
 	if s.viewLayer != nil {
 		_ = s.viewLayer.Close()
 	}
@@ -308,7 +316,9 @@ func (s *Session) close(tx *world.Tx, c Controllable) {
 	_ = s.offHand.Close()
 	_ = s.armour.Close()
 
-	s.chunkLoader.Close(tx)
+	if tx != nil {
+		s.chunkLoader.Close(tx)
+	}
 
 	if !s.conf.QuitMessage.Zero() {
 		chat.Global.Writet(s.conf.QuitMessage, s.conn.IdentityData().DisplayName)
@@ -317,7 +327,9 @@ func (s *Session) close(tx *world.Tx, c Controllable) {
 
 	// Note: Be aware of where RemoveEntity is called. This must not be done too
 	// early.
-	tx.RemoveEntity(c)
+	if tx != nil {
+		tx.RemoveEntity(c)
+	}
 	_ = s.ent.Close()
 
 	// This should always be called last due to the timing of the removal of
@@ -348,6 +360,22 @@ func (s *Session) Latency() time.Duration {
 	return s.conn.Latency()
 }
 
+// withControllable runs f with the current Controllable on its world owner.
+// It is for off-owner session goroutines; callbacks that already have a
+// *world.Tx should use it directly instead.
+func (s *Session) withControllable(ctx context.Context, f func(tx *world.Tx, c Controllable) error) error {
+	_, err := world.CallRef(ctx, world.NewEntityRef[Controllable](s.ent), func(tx *world.Tx, c Controllable) (struct{}, error) {
+		return struct{}{}, f(tx, c)
+	})
+	return err
+}
+
+// sessionOwnerStopped reports whether err means the session's player can no
+// longer run owner callbacks, so session goroutines should stop quietly.
+func sessionOwnerStopped(err error) bool {
+	return errors.Is(err, world.ErrEntityClosed) || errors.Is(err, world.ErrWorldClosed) || errors.Is(err, world.ErrTaskCancelled)
+}
+
 // ClientData returns the login.ClientData of the underlying *minecraft.Conn.
 func (s *Session) ClientData() login.ClientData {
 	return s.conn.ClientData()
@@ -360,24 +388,34 @@ func (s *Session) handlePackets() {
 		// First close the Controllable. This might lead to a world change
 		// (player might be dead while disconnecting, in which case it will
 		// respawn first).
-		s.ent.ExecWorld(func(tx *world.Tx, e world.Entity) {
-			_ = e.(Controllable).Close()
-		})
+		if err := s.withControllable(context.Background(), func(_ *world.Tx, c Controllable) error {
+			_ = c.Close()
+			return nil
+		}); err != nil && !sessionOwnerStopped(err) {
+			s.conf.Log.Debug("close controllable: " + err.Error())
+		}
 		// Because the player might no longer be in the same world after
 		// closing, we create a new transaction
-		s.ent.ExecWorld(func(tx *world.Tx, e world.Entity) {
-			s.Close(tx, e.(Controllable))
-		})
+		if err := s.withControllable(context.Background(), func(tx *world.Tx, c Controllable) error {
+			s.Close(tx, c)
+			return nil
+		}); err != nil && !sessionOwnerStopped(err) {
+			s.conf.Log.Debug("close session: " + err.Error())
+		}
 	}()
 	for {
 		pk, err := s.conn.ReadPacket()
 		if err != nil {
 			return
 		}
-		s.ent.ExecWorld(func(tx *world.Tx, e world.Entity) {
-			err = s.handlePacket(pk, tx, e.(Controllable))
+		err = s.withControllable(context.Background(), func(tx *world.Tx, c Controllable) error {
+			return s.handlePacket(pk, tx, c)
 		})
 		if err != nil {
+			world.RethrowPanic(err)
+			if sessionOwnerStopped(err) {
+				return
+			}
 			s.conf.Log.Debug("process packet: " + err.Error())
 			return
 		}
@@ -396,20 +434,23 @@ func (s *Session) background() {
 		i          int
 	)
 
-	s.ent.ExecWorld(func(tx *world.Tx, e world.Entity) {
-		co := e.(Controllable)
-		r = s.sendAvailableCommands(co, softEnums)
-		enums, enumValues = s.enums(co)
-	})
+	if err := s.withControllable(context.Background(), func(_ *world.Tx, c Controllable) error {
+		r = s.sendAvailableCommands(c, softEnums)
+		enums, enumValues = s.enums(c)
+		return nil
+	}); err != nil {
+		if !sessionOwnerStopped(err) {
+			s.conf.Log.Debug("prepare command updates: " + err.Error())
+		}
+		return
+	}
 
 	t := time.NewTicker(time.Second / 20)
 	defer t.Stop()
 	for {
 		select {
 		case <-t.C:
-			s.ent.ExecWorld(func(tx *world.Tx, e world.Entity) {
-				c := e.(Controllable)
-
+			if err := s.withControllable(context.Background(), func(tx *world.Tx, c Controllable) error {
 				if i++; i%20 == 0 {
 					// Enum resending happens relatively often and frequent updates are more important than with full
 					// command changes. Those are generally only related to permission changes, which doesn't happen often.
@@ -422,7 +463,13 @@ func (s *Session) background() {
 					}
 				}
 				s.sendChunks(tx, c)
-			})
+				return nil
+			}); err != nil {
+				if !sessionOwnerStopped(err) {
+					s.conf.Log.Debug("update session background: " + err.Error())
+				}
+				return
+			}
 		case <-s.closeBackground:
 			return
 		}

--- a/server/world/block.go
+++ b/server/world/block.go
@@ -66,9 +66,9 @@ type Liquid interface {
 	LiquidType() string
 	// Harden checks if the block should harden when looking at the surrounding blocks and sets the position
 	// to the hardened block when adequate. If the block was hardened, the method returns true.
-	Harden(pos cube.Pos, tx *Context, flownIntoBy *cube.Pos) bool
+	Harden(pos cube.Pos, tx *Tx, flownIntoBy *cube.Pos) bool
 	// LiquidRemoveBlock is called when the liquid flows into and removes the block passed.
-	LiquidRemoveBlock(pos cube.Pos, tx *Context, removed Block)
+	LiquidRemoveBlock(pos cube.Pos, tx *Tx, removed Block)
 }
 
 // Conductor represents a block that can conduct a redstone signal.
@@ -83,7 +83,7 @@ type Conductor interface {
 	// cannot power solid blocks themselves or travel further.
 	// The accountForDust parameter indicates whether redstone dust should be considered when
 	// calculating power levels.
-	WeakPower(pos cube.Pos, face cube.Face, tx *Context, accountForDust bool) int
+	WeakPower(pos cube.Pos, face cube.Face, tx *Tx, accountForDust bool) int
 
 	// StrongPower returns the strong power level emitted by this conductor toward a neighbouring
 	// receiver. The face argument uses the same convention as WeakPower.
@@ -92,7 +92,7 @@ type Conductor interface {
 	// faces. Strong power can also directly power any redstone component.
 	// The accountForDust parameter indicates whether redstone dust should be considered when
 	// calculating power levels.
-	StrongPower(pos cube.Pos, face cube.Face, tx *Context, accountForDust bool) int
+	StrongPower(pos cube.Pos, face cube.Face, tx *Tx, accountForDust bool) int
 }
 
 // WeakBlockPowerer represents a conductor whose weak power may weakly power an adjacent conductive block. Weakly
@@ -118,7 +118,7 @@ type RedstonePowerRelayer interface {
 type RedstoneUpdater interface {
 	Block
 	// RedstoneUpdate is called when a change in redstone signal is computed.
-	RedstoneUpdate(pos cube.Pos, tx *Context)
+	RedstoneUpdate(pos cube.Pos, tx *Tx)
 }
 
 // RegisterBlock registers the Block passed in the DefaultBlockRegistry.
@@ -182,7 +182,7 @@ func CustomBlocks() map[string]CustomBlock {
 type RandomTicker interface {
 	// RandomTick handles a random tick of the block at the position passed. Additionally, a rand.RandSource
 	// instance is passed which may be used to generate values randomly without locking.
-	RandomTick(pos cube.Pos, tx *Context, r *rand.Rand)
+	RandomTick(pos cube.Pos, tx *Tx, r *rand.Rand)
 }
 
 // ScheduledTicker represents a block that executes an action when it has a block update scheduled, such as
@@ -191,14 +191,14 @@ type ScheduledTicker interface {
 	// ScheduledTick handles a scheduled tick initiated by an event in one of the neighbouring blocks, such as
 	// when a block is placed or broken. Additionally, a rand.RandSource instance is passed which may be used to
 	// generate values randomly without locking.
-	ScheduledTick(pos cube.Pos, tx *Context, r *rand.Rand)
+	ScheduledTick(pos cube.Pos, tx *Tx, r *rand.Rand)
 }
 
 // TickerBlock is an implementation of NBTer with an additional Tick method that is called on every world
 // tick for loaded blocks that implement this interface.
 type TickerBlock interface {
 	NBTer
-	Tick(currentTick int64, pos cube.Pos, tx *Context)
+	Tick(currentTick int64, pos cube.Pos, tx *Tx)
 }
 
 // NeighbourUpdateTicker represents a block that is updated when a block adjacent to it is updated, either
@@ -206,7 +206,7 @@ type TickerBlock interface {
 type NeighbourUpdateTicker interface {
 	// NeighbourUpdateTick handles a neighbouring block being updated. The position of that block and the
 	// position of this block is passed.
-	NeighbourUpdateTick(pos, changedNeighbour cube.Pos, tx *Context)
+	NeighbourUpdateTick(pos, changedNeighbour cube.Pos, tx *Tx)
 }
 
 // NBTer represents either an item or a block which may decode NBT data and encode to NBT data. Typically,
@@ -227,7 +227,7 @@ type LiquidDisplacer interface {
 	// SideClosed checks if a position on the side of the block placed in the world at a specific position is
 	// closed. When this returns true (for example, when the side is below the position and the block is a
 	// slab), liquid inside the displacer won't flow from pos into side.
-	SideClosed(pos, side cube.Pos, tx *Context) bool
+	SideClosed(pos, side cube.Pos, tx *Tx) bool
 }
 
 // lightEmitter is identical to a block.LightEmitter.

--- a/server/world/block.go
+++ b/server/world/block.go
@@ -66,9 +66,9 @@ type Liquid interface {
 	LiquidType() string
 	// Harden checks if the block should harden when looking at the surrounding blocks and sets the position
 	// to the hardened block when adequate. If the block was hardened, the method returns true.
-	Harden(pos cube.Pos, tx *Tx, flownIntoBy *cube.Pos) bool
+	Harden(pos cube.Pos, tx *Context, flownIntoBy *cube.Pos) bool
 	// LiquidRemoveBlock is called when the liquid flows into and removes the block passed.
-	LiquidRemoveBlock(pos cube.Pos, tx *Tx, removed Block)
+	LiquidRemoveBlock(pos cube.Pos, tx *Context, removed Block)
 }
 
 // Conductor represents a block that can conduct a redstone signal.
@@ -83,7 +83,7 @@ type Conductor interface {
 	// cannot power solid blocks themselves or travel further.
 	// The accountForDust parameter indicates whether redstone dust should be considered when
 	// calculating power levels.
-	WeakPower(pos cube.Pos, face cube.Face, tx *Tx, accountForDust bool) int
+	WeakPower(pos cube.Pos, face cube.Face, tx *Context, accountForDust bool) int
 
 	// StrongPower returns the strong power level emitted by this conductor toward a neighbouring
 	// receiver. The face argument uses the same convention as WeakPower.
@@ -92,7 +92,7 @@ type Conductor interface {
 	// faces. Strong power can also directly power any redstone component.
 	// The accountForDust parameter indicates whether redstone dust should be considered when
 	// calculating power levels.
-	StrongPower(pos cube.Pos, face cube.Face, tx *Tx, accountForDust bool) int
+	StrongPower(pos cube.Pos, face cube.Face, tx *Context, accountForDust bool) int
 }
 
 // WeakBlockPowerer represents a conductor whose weak power may weakly power an adjacent conductive block. Weakly
@@ -106,7 +106,7 @@ type WeakBlockPowerer interface {
 }
 
 // RedstonePowerRelayer represents a block with custom behaviour for whether
-// neighbouring redstone power may be relayed through it by Tx.RedstonePower.
+// neighbouring redstone power may be relayed through it by Context.RedstonePower.
 type RedstonePowerRelayer interface {
 	Block
 	// RelaysRedstonePowerThrough reports whether this non-conductor block may
@@ -118,7 +118,7 @@ type RedstonePowerRelayer interface {
 type RedstoneUpdater interface {
 	Block
 	// RedstoneUpdate is called when a change in redstone signal is computed.
-	RedstoneUpdate(pos cube.Pos, tx *Tx)
+	RedstoneUpdate(pos cube.Pos, tx *Context)
 }
 
 // RegisterBlock registers the Block passed in the DefaultBlockRegistry.
@@ -182,7 +182,7 @@ func CustomBlocks() map[string]CustomBlock {
 type RandomTicker interface {
 	// RandomTick handles a random tick of the block at the position passed. Additionally, a rand.RandSource
 	// instance is passed which may be used to generate values randomly without locking.
-	RandomTick(pos cube.Pos, tx *Tx, r *rand.Rand)
+	RandomTick(pos cube.Pos, tx *Context, r *rand.Rand)
 }
 
 // ScheduledTicker represents a block that executes an action when it has a block update scheduled, such as
@@ -191,14 +191,14 @@ type ScheduledTicker interface {
 	// ScheduledTick handles a scheduled tick initiated by an event in one of the neighbouring blocks, such as
 	// when a block is placed or broken. Additionally, a rand.RandSource instance is passed which may be used to
 	// generate values randomly without locking.
-	ScheduledTick(pos cube.Pos, tx *Tx, r *rand.Rand)
+	ScheduledTick(pos cube.Pos, tx *Context, r *rand.Rand)
 }
 
 // TickerBlock is an implementation of NBTer with an additional Tick method that is called on every world
 // tick for loaded blocks that implement this interface.
 type TickerBlock interface {
 	NBTer
-	Tick(currentTick int64, pos cube.Pos, tx *Tx)
+	Tick(currentTick int64, pos cube.Pos, tx *Context)
 }
 
 // NeighbourUpdateTicker represents a block that is updated when a block adjacent to it is updated, either
@@ -206,7 +206,7 @@ type TickerBlock interface {
 type NeighbourUpdateTicker interface {
 	// NeighbourUpdateTick handles a neighbouring block being updated. The position of that block and the
 	// position of this block is passed.
-	NeighbourUpdateTick(pos, changedNeighbour cube.Pos, tx *Tx)
+	NeighbourUpdateTick(pos, changedNeighbour cube.Pos, tx *Context)
 }
 
 // NBTer represents either an item or a block which may decode NBT data and encode to NBT data. Typically,
@@ -227,7 +227,7 @@ type LiquidDisplacer interface {
 	// SideClosed checks if a position on the side of the block placed in the world at a specific position is
 	// closed. When this returns true (for example, when the side is below the position and the block is a
 	// slab), liquid inside the displacer won't flow from pos into side.
-	SideClosed(pos, side cube.Pos, tx *Tx) bool
+	SideClosed(pos, side cube.Pos, tx *Context) bool
 }
 
 // lightEmitter is identical to a block.LightEmitter.

--- a/server/world/conf.go
+++ b/server/world/conf.go
@@ -72,11 +72,14 @@ type Config struct {
 	// use NewBlockRegistry(), register blocks/states, and call Finalize().
 	Blocks BlockRegistry
 
-	// Synchronous makes the World run without any background goroutines.
-	// Tasks from World.Do and Call run on the calling goroutine, the World is
-	// not saved or unloaded automatically, and time only passes on explicit
-	// World.AdvanceTick calls. This makes Synchronous Worlds deterministic and
-	// well suited to unit tests that need a World to interact with.
+	// Synchronous removes the World's own background goroutines. Immediate tasks
+	// from World.Do and Call run on the calling goroutine, the World is not saved
+	// or unloaded automatically, and time only passes on explicit
+	// World.AdvanceTick calls. World.DoAfter and entity work scheduled before an
+	// entity enters a world still use background goroutines and wall-clock
+	// delays; callers must synchronise on the returned Task. This makes
+	// Synchronous Worlds well suited to unit tests that need a World to interact
+	// with.
 	// A Synchronous World must be driven from one goroutine. Do, Call and
 	// AdvanceTick are not safe to call concurrently, including from delayed
 	// item or death callbacks.

--- a/server/world/conf.go
+++ b/server/world/conf.go
@@ -73,11 +73,11 @@ type Config struct {
 	Blocks BlockRegistry
 
 	// Synchronous makes the World run without any background goroutines.
-	// Transactions from World.Exec run on the calling goroutine, the World is
+	// Tasks from World.Do and Call run on the calling goroutine, the World is
 	// not saved or unloaded automatically, and time only passes on explicit
 	// World.AdvanceTick calls. This makes Synchronous Worlds deterministic and
 	// well suited to unit tests that need a World to interact with.
-	// A Synchronous World must be driven from one goroutine. Exec and
+	// A Synchronous World must be driven from one goroutine. Do, Call and
 	// AdvanceTick are not safe to call concurrently, including from delayed
 	// item or death callbacks.
 	Synchronous bool
@@ -133,6 +133,7 @@ func (conf Config) New() *World {
 		viewers:          make(map[*Loader]Viewer),
 		chunks:           make(map[ChunkPos]*Column),
 		queueClosing:     make(chan struct{}),
+		closeStarted:     make(chan struct{}),
 		closing:          make(chan struct{}),
 		queue:            make(chan transaction, 128),
 		r:                rand.New(conf.RandSource),
@@ -155,6 +156,6 @@ func (conf Config) New() *World {
 		go w.handleTransactions()
 	}
 
-	<-w.Exec(t.tick)
+	<-w.exec(t.tick)
 	return w
 }

--- a/server/world/entity.go
+++ b/server/world/entity.go
@@ -18,7 +18,7 @@ import (
 // ID and bounding box of an Entity.
 type EntityType interface {
 	// Open returns an Entity implementation in the context of a transaction.
-	Open(tx *Tx, handle *EntityHandle, data *EntityData) Entity
+	Open(tx *Context, handle *EntityHandle, data *EntityData) Entity
 
 	// EncodeEntity converts the Entity to its encoded representation: It
 	// returns the type of the Minecraft Entity, for example
@@ -51,6 +51,17 @@ type EntityHandle struct {
 	worldless    *atomic.Bool
 	weakTxActive bool
 	w            *World
+	// worldReady becomes true only after AddEntity finishes registering and
+	// opening the entity in w. Scheduled callbacks wait for this handoff.
+	worldReady bool
+	// worldVersion increments on every change to w, letting weak transactions
+	// detect that the entity moved while they were queued.
+	worldVersion atomic.Uint64
+	// closed closes once the handle is closed. worldChanged, created lazily
+	// for delayed schedulers, is closed and dropped on every change to w.
+	closed       chan struct{}
+	worldChanged chan struct{}
+	closeOnce    sync.Once
 
 	data EntityData
 
@@ -74,7 +85,7 @@ type EntitySpawnOpts struct {
 }
 
 // New creates an EntityHandle using an EntityType and EntityConfig passed. The
-// EntityHandle may be added to a world by calling Tx.AddEntity().
+// EntityHandle may be added to a world by calling Context.AddEntity().
 // The spawn conditions depend on the options set in opts.
 func (opts EntitySpawnOpts) New(t EntityType, conf EntityConfig) *EntityHandle {
 	if opts.ID == uuid.Nil {
@@ -83,7 +94,13 @@ func (opts EntitySpawnOpts) New(t EntityType, conf EntityConfig) *EntityHandle {
 		opts.ID = uuid.New()
 		clear(opts.ID[:8])
 	}
-	handle := &EntityHandle{id: opts.ID, t: t, cond: sync.NewCond(&sync.Mutex{}), worldless: &atomic.Bool{}}
+	handle := &EntityHandle{
+		id:        opts.ID,
+		t:         t,
+		cond:      sync.NewCond(&sync.Mutex{}),
+		worldless: &atomic.Bool{},
+		closed:    make(chan struct{}),
+	}
 	handle.worldless.Store(true)
 	handle.data.Pos, handle.data.Rot, handle.data.Vel = opts.Position, opts.Rotation, opts.Velocity
 	handle.data.Name = opts.NameTag
@@ -92,7 +109,7 @@ func (opts EntitySpawnOpts) New(t EntityType, conf EntityConfig) *EntityHandle {
 }
 
 // NewEntity creates an EntityHandle using an EntityType and EntityConfig
-// passed. The EntityHandle may be added to a world by calling Tx.AddEntity().
+// passed. The EntityHandle may be added to a world by calling Context.AddEntity().
 // NewEntity uses the zero value for EntitySpawnOpts.
 func NewEntity(t EntityType, conf EntityConfig) *EntityHandle {
 	var opts EntitySpawnOpts
@@ -102,7 +119,12 @@ func NewEntity(t EntityType, conf EntityConfig) *EntityHandle {
 // entityFromData reads an entity from the decoded NBT data passed and returns
 // an EntityHandle.
 func entityFromData(t EntityType, id int64, data map[string]any) *EntityHandle {
-	handle := &EntityHandle{t: t, cond: sync.NewCond(&sync.Mutex{}), worldless: &atomic.Bool{}}
+	handle := &EntityHandle{
+		t:         t,
+		cond:      sync.NewCond(&sync.Mutex{}),
+		worldless: &atomic.Bool{},
+		closed:    make(chan struct{}),
+	}
 	binary.LittleEndian.PutUint64(handle.id[8:], uint64(id))
 	handle.decodeNBT(data)
 	t.DecodeNBT(data, &handle.data)
@@ -114,10 +136,10 @@ func (e *EntityHandle) Type() EntityType {
 	return e.t
 }
 
-// Entity attempts to convert an EntityHandle to an Entity using the Tx passed.
+// Entity attempts to convert an EntityHandle to an Entity using the Context passed.
 // A non-nil Entity is returned only if the entity's world matches the world of
-// the Tx. If they do not match, false is returned.
-func (e *EntityHandle) Entity(tx *Tx) (Entity, bool) {
+// the Context. If they do not match, false is returned.
+func (e *EntityHandle) Entity(tx *Context) (Entity, bool) {
 	if e == nil || e.w != tx.World() {
 		return nil, false
 	}
@@ -125,11 +147,11 @@ func (e *EntityHandle) Entity(tx *Tx) (Entity, bool) {
 }
 
 // mustEntity calls Entity but panics if the worlds do not match.
-func (e *EntityHandle) mustEntity(tx *Tx) Entity {
+func (e *EntityHandle) mustEntity(tx *Context) Entity {
 	if ent, ok := e.Entity(tx); ok {
 		return ent
 	}
-	panic("can't load entity with Tx of different world")
+	panic("can't load entity with Context of different world")
 }
 
 // UUID returns the identifier of the EntityHandle.
@@ -137,36 +159,55 @@ func (e *EntityHandle) UUID() uuid.UUID {
 	return e.id
 }
 
-// Close closes the EntityHandle. Any subsequent call to ExecWorld will return
-// immediately without the transaction function being called. Close always
-// returns nil.
+// Close closes the EntityHandle. Any subsequently scheduled work will fail
+// with ErrEntityClosed without the transaction function being called. Close
+// always returns nil.
 func (e *EntityHandle) Close() error {
-	e.setAndUnlockWorld(closeWorld)
+	e.closeOnce.Do(func() {
+		e.setAndUnlockWorld(closeWorld)
+		close(e.closed)
+	})
 	return nil
 }
 
-// ExecWorld obtains the EntityHandle's World in a thread-safe way and opens a
-// transaction in it when it does. If the EntityHandle has not been added to a
-// world, ExecWorld will block until the EntityHandle is added to a World and
-// run the transaction function once it is. If the Entity is closed before
-// ExecWorld is called, ExecWorld will return false immediately without running
-// the transaction function.
-func (e *EntityHandle) ExecWorld(f func(tx *Tx, e Entity)) bool {
-	return e.execWorld(f, false)
+func cancelled(c <-chan struct{}) bool {
+	if c == nil {
+		return false
+	}
+	select {
+	case <-c:
+		return true
+	default:
+		return false
+	}
 }
 
 // execWorld uses a sync.Cond to synchronise access to the handler's world. We
 // are dealing with a rather complicated synchronisation pattern here. The goal
-// for ExecWorld is to block until e.w becomes accessible. Meanwhile, World.Exec
+// for execWorld is to block until e.w becomes accessible. Meanwhile, World.exec
 // may also affect e.w, which execWorld needs to deal with.
-func (e *EntityHandle) execWorld(f func(tx *Tx, e Entity), weak bool) bool {
+func (e *EntityHandle) execWorld(f func(tx *Context, e Entity), weak bool, cancel <-chan struct{}, allowedCloseWorld *World) bool {
 	e.cond.L.Lock()
-	for e.w == nil || (!weak && e.weakTxActive) {
+	for e.w == nil || (e.w != closeWorld && (!e.worldReady || (!weak && e.weakTxActive))) {
+		if cancelled(cancel) {
+			if weak {
+				e.clearWeakTxActiveLocked()
+			}
+			e.cond.L.Unlock()
+			return false
+		}
 		// Wait suspends the current goroutine and unlocks e.cond.L, until
 		// e.cond.Broadcast() is called. After this, one of the goroutines
 		// waiting will acquire a lock of e.cond.L again. This means that only
 		// one goroutine will run the code after this simultaneously.
 		e.cond.Wait()
+	}
+	if cancelled(cancel) {
+		if weak {
+			e.clearWeakTxActiveLocked()
+		}
+		e.cond.L.Unlock()
+		return false
 	}
 	// If a goroutine manages to exit the for loop, it will have acquired a lock
 	// on e.cond.L. This also means that e.w can be assumed to not be nil here.
@@ -176,10 +217,20 @@ func (e *EntityHandle) execWorld(f func(tx *Tx, e Entity), weak bool) bool {
 	e.worldless.Store(false)
 	if e.w == closeWorld {
 		// EntityHandle was closed. No need to continue.
+		if weak {
+			e.clearWeakTxActiveLocked()
+		}
 		e.cond.L.Unlock()
 		return false
 	}
-	// We now arrive at the more complicated part. When we call e.w.Exec(), our
+	if e.w.closed.Load() && !e.w.closeAcceptingEntityTasks.Load() && e.w != allowedCloseWorld {
+		if weak {
+			e.clearWeakTxActiveLocked()
+		}
+		e.cond.L.Unlock()
+		return false
+	}
+	// We now arrive at the more complicated part. When we call e.w.exec(), our
 	// transaction must await earlier transactions in the world. If one of those
 	// earlier transactions tries to change e.w (through e.unsetAndLockWorld()
 	// or e.setAndUnlockWorld()), it must lock e.cond.L. This would lead to a
@@ -190,14 +241,27 @@ func (e *EntityHandle) execWorld(f func(tx *Tx, e Entity), weak bool) bool {
 	// transaction turns out to be invalidated (ret == false), we simply try
 	// again, this time with e.execWorld(f, true) to make this goroutine bypass
 	// any goroutines still awaiting e.cond.
-	ret := e.weakExec(func(tx *Tx) { f(tx, e.mustEntity(tx)) })
+	var ran atomic.Bool
+	ret := e.weakExec(func(tx *Context) {
+		ent := e.mustEntity(tx)
+		ran.Store(true)
+		f(tx, ent)
+	}, allowedCloseWorld)
+	if !ret && e.w != nil && e.w != closeWorld && e.w.closed.Load() && !e.w.closeAcceptingEntityTasks.Load() && e.w != allowedCloseWorld {
+		e.clearWeakTxActiveLocked()
+		e.cond.L.Unlock()
+		return false
+	}
 	e.cond.L.Unlock()
 
+	if ran.Load() {
+		return true
+	}
 	if !ret {
 		// Our weak transaction was suspended. We try again, this time with
 		// e.execWorld(f, true) to make this goroutine bypass any goroutines
 		// still awaiting e.cond.
-		return e.execWorld(f, true)
+		return e.execWorld(f, true, cancel, allowedCloseWorld)
 	}
 	return true
 }
@@ -205,17 +269,20 @@ func (e *EntityHandle) execWorld(f func(tx *Tx, e Entity), weak bool) bool {
 // weakExec performs a "weak transaction". It adds a transaction to the world
 // that is invalidated when e.worldless is set to true. In this case, weakExec
 // returns false. If the weak transaction is successfully executed, it returns
-// true, and any calls to ExecWorld waiting on e.cond are awakened. The goal of
+// true, and any calls to execWorld waiting on e.cond are awakened. The goal of
 // weakExec is to suspend the current goroutine and unlock e.cond.L while
 // waiting for previous transactions to finish.
-func (e *EntityHandle) weakExec(f ExecFunc) bool {
+func (e *EntityHandle) weakExec(f execFunc, allowedCloseWorld *World) bool {
 	e.weakTxActive = true
+	w, version := e.w, e.worldVersion.Load()
 
 	// We create a weak transaction and start a for loop to listen for the
 	// length of the channel. This might look weird, but the crucial part here
 	// is the call to e.cond.Wait(), which unlocks e.cond.L. This is required
 	// to prevent a deadlock if an earlier transaction tries to change e.w.
-	c := e.w.weakExec(e.worldless, e.cond, f)
+	c := w.weakExec(func() bool {
+		return e.worldVersion.Load() == version && !e.worldless.Load()
+	}, e.cond, f, w == allowedCloseWorld)
 	for len(c) == 0 && e.w != closeWorld {
 		// Calling e.cond.Wait() here will free the lock on e.cond.L until our
 		// transaction finishes. e.w.weakExec() ensures that e.cond.Broadcast()
@@ -223,8 +290,6 @@ func (e *EntityHandle) weakExec(f ExecFunc) bool {
 		// continue after that.
 		e.cond.Wait()
 	}
-	// If the EntityHandle was closed (e.w == closeWorld), we treat the
-	// transaction as successful, because all transactions must be cancelled.
 	if e.w != closeWorld && !<-c {
 		// Weak transaction was suspended. Return false and try again.
 		return false
@@ -232,14 +297,22 @@ func (e *EntityHandle) weakExec(f ExecFunc) bool {
 	// After setting e.weakTxActive back to false, we must Broadcast to make
 	// sure any goroutines waiting in e.execWorld as a result of the
 	// e.weakTxActive condition can continue.
+	closed := e.w == closeWorld
 	e.weakTxActive = false
 	e.cond.Broadcast()
-	return true
+	return !closed
+}
+
+func (e *EntityHandle) clearWeakTxActiveLocked() {
+	if e.weakTxActive {
+		e.weakTxActive = false
+		e.cond.Broadcast()
+	}
 }
 
 var closeWorld = &World{}
 
-// unsetAndLockWorld sets e.w to nil, causing any subsequent calls to ExecWorld
+// unsetAndLockWorld sets e.w to nil, causing any subsequent calls to execWorld
 // to block until e.w is set to a non-nil value.
 func (e *EntityHandle) unsetAndLockWorld() {
 	e.cond.L.Lock()
@@ -247,10 +320,13 @@ func (e *EntityHandle) unsetAndLockWorld() {
 
 	e.worldless.Store(true)
 	e.w = nil
+	e.worldReady = false
+	e.worldVersion.Add(1)
+	e.notifyWorldChangedLocked()
 }
 
-// setAndUnlockWorld sets e.w to a World passed and broadcasts e.cond, so that
-// any goroutines waiting for a non-nil world are awoken.
+// setAndUnlockWorld starts binding e to w. Scheduled callbacks remain blocked
+// until markWorldReady is called after AddEntity finishes.
 func (e *EntityHandle) setAndUnlockWorld(w *World) {
 	e.cond.L.Lock()
 	defer e.cond.L.Unlock()
@@ -259,6 +335,27 @@ func (e *EntityHandle) setAndUnlockWorld(w *World) {
 		panic("cannot add entity to new world before removing from old world")
 	}
 	e.w = w
+	e.worldReady = false
+	e.worldVersion.Add(1)
+	e.notifyWorldChangedLocked()
+}
+
+// markWorldReady wakes scheduled callbacks after AddEntity has fully opened
+// and registered the entity in w.
+func (e *EntityHandle) markWorldReady(w *World) {
+	e.cond.L.Lock()
+	defer e.cond.L.Unlock()
+	if e.w == w {
+		e.worldReady = true
+		e.cond.Broadcast()
+	}
+}
+
+func (e *EntityHandle) notifyWorldChangedLocked() {
+	if e.worldChanged != nil {
+		close(e.worldChanged)
+		e.worldChanged = nil
+	}
 	e.cond.Broadcast()
 }
 
@@ -317,7 +414,7 @@ type Entity interface {
 type TickerEntity interface {
 	Entity
 	// Tick ticks the Entity with the current World and tick passed.
-	Tick(tx *Tx, current int64)
+	Tick(tx *Context, current int64)
 }
 
 // EntityAction represents an action that may be performed by an Entity. Typically, these actions are sent to

--- a/server/world/entity.go
+++ b/server/world/entity.go
@@ -17,8 +17,8 @@ import (
 // EntityType is the type of Entity. It specifies the name, encoded Entity
 // ID and bounding box of an Entity.
 type EntityType interface {
-	// Open returns an Entity implementation in the context of a transaction.
-	Open(tx *Context, handle *EntityHandle, data *EntityData) Entity
+	// Open returns an Entity implementation in a transaction.
+	Open(tx *Tx, handle *EntityHandle, data *EntityData) Entity
 
 	// EncodeEntity converts the Entity to its encoded representation: It
 	// returns the type of the Minecraft Entity, for example
@@ -85,7 +85,7 @@ type EntitySpawnOpts struct {
 }
 
 // New creates an EntityHandle using an EntityType and EntityConfig passed. The
-// EntityHandle may be added to a world by calling Context.AddEntity().
+// EntityHandle may be added to a world by calling Tx.AddEntity().
 // The spawn conditions depend on the options set in opts.
 func (opts EntitySpawnOpts) New(t EntityType, conf EntityConfig) *EntityHandle {
 	if opts.ID == uuid.Nil {
@@ -109,7 +109,7 @@ func (opts EntitySpawnOpts) New(t EntityType, conf EntityConfig) *EntityHandle {
 }
 
 // NewEntity creates an EntityHandle using an EntityType and EntityConfig
-// passed. The EntityHandle may be added to a world by calling Context.AddEntity().
+// passed. The EntityHandle may be added to a world by calling Tx.AddEntity().
 // NewEntity uses the zero value for EntitySpawnOpts.
 func NewEntity(t EntityType, conf EntityConfig) *EntityHandle {
 	var opts EntitySpawnOpts
@@ -136,10 +136,10 @@ func (e *EntityHandle) Type() EntityType {
 	return e.t
 }
 
-// Entity attempts to convert an EntityHandle to an Entity using the Context passed.
+// Entity attempts to convert an EntityHandle to an Entity using the Tx passed.
 // A non-nil Entity is returned only if the entity's world matches the world of
-// the Context. If they do not match, false is returned.
-func (e *EntityHandle) Entity(tx *Context) (Entity, bool) {
+// the Tx. If they do not match, false is returned.
+func (e *EntityHandle) Entity(tx *Tx) (Entity, bool) {
 	if e == nil || e.w != tx.World() {
 		return nil, false
 	}
@@ -147,16 +147,29 @@ func (e *EntityHandle) Entity(tx *Context) (Entity, bool) {
 }
 
 // mustEntity calls Entity but panics if the worlds do not match.
-func (e *EntityHandle) mustEntity(tx *Context) Entity {
+func (e *EntityHandle) mustEntity(tx *Tx) Entity {
 	if ent, ok := e.Entity(tx); ok {
 		return ent
 	}
-	panic("can't load entity with Context of different world")
+	panic("can't load entity with Tx of different world")
 }
 
 // UUID returns the identifier of the EntityHandle.
 func (e *EntityHandle) UUID() uuid.UUID {
 	return e.id
+}
+
+// Closed reports whether the EntityHandle has been closed.
+func (e *EntityHandle) Closed() bool {
+	if e == nil {
+		return true
+	}
+	select {
+	case <-e.closed:
+		return true
+	default:
+		return false
+	}
 }
 
 // Close closes the EntityHandle. Any subsequently scheduled work will fail
@@ -186,7 +199,7 @@ func cancelled(c <-chan struct{}) bool {
 // are dealing with a rather complicated synchronisation pattern here. The goal
 // for execWorld is to block until e.w becomes accessible. Meanwhile, World.exec
 // may also affect e.w, which execWorld needs to deal with.
-func (e *EntityHandle) execWorld(f func(tx *Context, e Entity), weak bool, cancel <-chan struct{}, allowedCloseWorld *World) bool {
+func (e *EntityHandle) execWorld(f func(tx *Tx, e Entity), weak bool, cancel <-chan struct{}, allowedCloseWorld *World) bool {
 	e.cond.L.Lock()
 	for e.w == nil || (e.w != closeWorld && (!e.worldReady || (!weak && e.weakTxActive))) {
 		if cancelled(cancel) {
@@ -242,7 +255,7 @@ func (e *EntityHandle) execWorld(f func(tx *Context, e Entity), weak bool, cance
 	// again, this time with e.execWorld(f, true) to make this goroutine bypass
 	// any goroutines still awaiting e.cond.
 	var ran atomic.Bool
-	ret := e.weakExec(func(tx *Context) {
+	ret := e.weakExec(func(tx *Tx) {
 		ent := e.mustEntity(tx)
 		ran.Store(true)
 		f(tx, ent)
@@ -414,7 +427,7 @@ type Entity interface {
 type TickerEntity interface {
 	Entity
 	// Tick ticks the Entity with the current World and tick passed.
-	Tick(tx *Context, current int64)
+	Tick(tx *Tx, current int64)
 }
 
 // EntityAction represents an action that may be performed by an Entity. Typically, these actions are sent to

--- a/server/world/entity_ref.go
+++ b/server/world/entity_ref.go
@@ -1,0 +1,74 @@
+package world
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// EntityRef is a stable, typed reference to an entity. The entity value T is
+// only handed to scheduled owner callbacks, where it is safe to use.
+type EntityRef[T Entity] struct {
+	h *EntityHandle
+}
+
+// NewEntityRef creates a typed reference from an EntityHandle.
+func NewEntityRef[T Entity](h *EntityHandle) EntityRef[T] { return EntityRef[T]{h: h} }
+
+// Handle returns the underlying stable entity handle.
+func (r EntityRef[T]) Handle() *EntityHandle { return r.h }
+
+// Do schedules f on the entity's current world owner, like EntityHandle.Do,
+// but hands f the entity as T. If the entity is no longer a T when the task
+// runs, the task fails with ErrEntityType.
+func (r EntityRef[T]) Do(f func(ctx *Context, e T)) *Task {
+	return r.h.schedule(typed(f))
+}
+
+// DoAfter schedules f on the entity's world owner after delay, typed like Do.
+func (r EntityRef[T]) DoAfter(delay time.Duration, f func(ctx *Context, e T)) *Task {
+	return r.h.scheduleAfter(delay, typed(f))
+}
+
+// typed wraps f so the scheduled entity is asserted to T before f runs.
+func typed[T Entity](f func(ctx *Context, e T)) func(*Context, Entity) error {
+	return func(ctx *Context, e Entity) error {
+		v, err := assertEntity[T](e)
+		if err != nil {
+			return err
+		}
+		f(ctx, v)
+		return nil
+	}
+}
+
+// CallRef runs f with the ref's entity on its current world owner and waits
+// for the typed result. Off-owner code only, like Call.
+func CallRef[R any, E Entity](ctx context.Context, ref EntityRef[E], f func(ctx *Context, e E) (R, error)) (R, error) {
+	var zero R
+	ctx, err := callContext(ctx)
+	if err != nil {
+		return zero, err
+	}
+	var result R
+	task := ref.h.schedule(func(wctx *Context, e Entity) error {
+		v, err := assertEntity[E](e)
+		if err != nil {
+			return err
+		}
+		var callErr error
+		result, callErr = f(wctx, v)
+		return callErr
+	})
+	return awaitTask(ctx, task, &result)
+}
+
+// assertEntity converts e to T, returning ErrEntityType if it no longer is one.
+func assertEntity[T Entity](e Entity) (T, error) {
+	v, ok := e.(T)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("%w: got %T", ErrEntityType, e)
+	}
+	return v, nil
+}

--- a/server/world/entity_ref.go
+++ b/server/world/entity_ref.go
@@ -21,43 +21,45 @@ func (r EntityRef[T]) Handle() *EntityHandle { return r.h }
 // Do schedules f on the entity's current world owner, like EntityHandle.Do,
 // but hands f the entity as T. If the entity is no longer a T when the task
 // runs, the task fails with ErrEntityType.
-func (r EntityRef[T]) Do(f func(ctx *Context, e T)) *Task {
+func (r EntityRef[T]) Do(f func(tx *Tx, e T)) *Task {
 	return r.h.schedule(typed(f))
 }
 
 // DoAfter schedules f on the entity's world owner after delay, typed like Do.
-func (r EntityRef[T]) DoAfter(delay time.Duration, f func(ctx *Context, e T)) *Task {
+func (r EntityRef[T]) DoAfter(delay time.Duration, f func(tx *Tx, e T)) *Task {
 	return r.h.scheduleAfter(delay, typed(f))
 }
 
 // typed wraps f so the scheduled entity is asserted to T before f runs.
-func typed[T Entity](f func(ctx *Context, e T)) func(*Context, Entity) error {
-	return func(ctx *Context, e Entity) error {
+func typed[T Entity](f func(tx *Tx, e T)) func(*Tx, Entity) error {
+	return func(tx *Tx, e Entity) error {
 		v, err := assertEntity[T](e)
 		if err != nil {
 			return err
 		}
-		f(ctx, v)
+		f(tx, v)
 		return nil
 	}
 }
 
 // CallRef runs f with the ref's entity on its current world owner and waits
-// for the typed result. Off-owner code only, like Call.
-func CallRef[R any, E Entity](ctx context.Context, ref EntityRef[E], f func(ctx *Context, e E) (R, error)) (R, error) {
-	var zero R
+// for the typed result. Off-owner code only, like Call. A panic in f is
+// recovered and returned as a *PanicError matching ErrTaskPanicked; call
+// RethrowPanic to restore panic semantics.
+func CallRef[T any, E Entity](ctx context.Context, ref EntityRef[E], f func(tx *Tx, e E) (T, error)) (T, error) {
+	var zero T
 	ctx, err := callContext(ctx)
 	if err != nil {
 		return zero, err
 	}
-	var result R
-	task := ref.h.schedule(func(wctx *Context, e Entity) error {
+	var result T
+	task := ref.h.schedule(func(tx *Tx, e Entity) error {
 		v, err := assertEntity[E](e)
 		if err != nil {
 			return err
 		}
 		var callErr error
-		result, callErr = f(wctx, v)
+		result, callErr = f(tx, v)
 		return callErr
 	})
 	return awaitTask(ctx, task, &result)

--- a/server/world/entity_schedule.go
+++ b/server/world/entity_schedule.go
@@ -1,0 +1,179 @@
+package world
+
+import "time"
+
+// Do schedules f to run with the entity on its current world owner and
+// returns immediately. If the entity is in no world yet, the task waits until
+// it enters one or the handle closes. The entity passed to f is only valid
+// inside f. On a synchronous World, f runs before Do returns.
+func (e *EntityHandle) Do(f func(ctx *Context, e Entity)) *Task {
+	return e.schedule(func(ctx *Context, e Entity) error {
+		f(ctx, e)
+		return nil
+	})
+}
+
+// DoAfter schedules f to run with the entity after delay, following the
+// entity if it changes worlds in the meantime.
+func (e *EntityHandle) DoAfter(delay time.Duration, f func(ctx *Context, e Entity)) *Task {
+	return e.scheduleAfter(delay, func(ctx *Context, e Entity) error {
+		f(ctx, e)
+		return nil
+	})
+}
+
+// schedule runs f on the entity's current world owner from a goroutine that
+// waits for the entity to be world-bound. It deliberately never enqueues onto
+// the current world directly: that would commit to one world and fail instead
+// of following the entity when it migrates.
+func (e *EntityHandle) schedule(f func(ctx *Context, e Entity) error) *Task {
+	task := newTask()
+	if e == nil {
+		task.failIfPending(ErrEntityClosed)
+		return task
+	}
+	task.setCancel(e.wakeScheduled)
+	w := e.trackCloseSchedule(task)
+	if !task.pending() {
+		return task
+	}
+	run := func() {
+		if w != nil {
+			defer w.scheduling.Done()
+		}
+		e.runScheduled(task, f, w)
+	}
+	if e.currentWorldSynchronous() {
+		run()
+	} else {
+		go run()
+	}
+	return task
+}
+
+// scheduleAfter runs its own timer loop instead of reusing World.DoAfter:
+// the entity may change worlds during the delay, so the loop re-reads the
+// current world's signals every iteration.
+func (e *EntityHandle) scheduleAfter(delay time.Duration, f func(ctx *Context, e Entity) error) *Task {
+	if delay <= 0 {
+		return e.schedule(f)
+	}
+	task := newTask()
+	if e == nil {
+		task.failIfPending(ErrEntityClosed)
+		return task
+	}
+	task.setCancel(e.wakeScheduled)
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		for {
+			closeStarted, worldChanged := e.currentWorldSignals()
+			select {
+			case <-timer.C:
+				if e.currentWorldClosing() {
+					task.failIfPending(ErrWorldClosed)
+					return
+				}
+				e.runScheduled(task, f, nil)
+				return
+			case <-task.Done():
+				return
+			case <-closeStarted:
+				if cs, _ := e.currentWorldSignals(); cs == closeStarted {
+					task.failIfPending(ErrWorldClosed)
+					return
+				}
+			case <-worldChanged:
+			case <-e.closed:
+				task.failIfPending(ErrEntityClosed)
+				return
+			}
+		}
+	}()
+	return task
+}
+
+// trackCloseSchedule registers entity work created during the world's close
+// transaction, so World.close drains it before shutting the queue down.
+func (e *EntityHandle) trackCloseSchedule(task *Task) *World {
+	e.cond.L.Lock()
+	defer e.cond.L.Unlock()
+	w := e.w
+	if w == nil || w == closeWorld || !w.closed.Load() {
+		return nil
+	}
+	w.scheduleMu.Lock()
+	defer w.scheduleMu.Unlock()
+	if !w.closeAcceptingEntityTasks.Load() {
+		task.failIfPending(ErrWorldClosed)
+		return nil
+	}
+	select {
+	case <-w.queueClosing:
+		task.failIfPending(ErrWorldClosed)
+		return nil
+	default:
+		w.scheduling.Add(1)
+		return w
+	}
+}
+
+// wakeScheduled wakes goroutines waiting on the handle's cond, so a scheduler
+// blocked in execWorld re-checks its cancel signal.
+func (e *EntityHandle) wakeScheduled() {
+	e.cond.L.Lock()
+	e.cond.Broadcast()
+	e.cond.L.Unlock()
+}
+
+// currentWorldSignals returns the current world's close channel and the
+// handle's world-change channel, creating the latter for this waiter if
+// needed.
+func (e *EntityHandle) currentWorldSignals() (<-chan struct{}, <-chan struct{}) {
+	e.cond.L.Lock()
+	defer e.cond.L.Unlock()
+	if e.worldChanged == nil {
+		e.worldChanged = make(chan struct{})
+	}
+	if e.w == nil || e.w == closeWorld {
+		return nil, e.worldChanged
+	}
+	return e.w.closeStarted, e.worldChanged
+}
+
+// currentWorldSynchronous reports whether the entity is bound to a
+// synchronous World.
+func (e *EntityHandle) currentWorldSynchronous() bool {
+	e.cond.L.Lock()
+	defer e.cond.L.Unlock()
+	return e.w != nil && e.w != closeWorld && e.worldReady && e.w.conf.Synchronous
+}
+
+// currentWorldClosing reports whether the entity's current world has started
+// closing.
+func (e *EntityHandle) currentWorldClosing() bool {
+	closeStarted, _ := e.currentWorldSignals()
+	return cancelled(closeStarted)
+}
+
+// runScheduled executes the scheduled entity callback via execWorld with the
+// same completion model as scheduledTransaction: run, drain deferred work,
+// finish the task.
+func (e *EntityHandle) runScheduled(task *Task, f func(ctx *Context, e Entity) error, allowedCloseWorld *World) {
+	run := e.execWorld(func(ctx *Context, ent Entity) {
+		if !task.begin() {
+			return
+		}
+		err := executeWithRecovery(ctx.w, func() error { return f(ctx, ent) })
+		ctx.runDeferred()
+		task.finish(err)
+	}, false, task.Done(), allowedCloseWorld)
+	if !run || task.pending() {
+		err := ErrEntityClosed
+		if e.currentWorldClosing() {
+			err = ErrWorldClosed
+		}
+		task.failIfPending(err)
+	}
+}

--- a/server/world/entity_schedule.go
+++ b/server/world/entity_schedule.go
@@ -6,18 +6,18 @@ import "time"
 // returns immediately. If the entity is in no world yet, the task waits until
 // it enters one or the handle closes. The entity passed to f is only valid
 // inside f. On a synchronous World, f runs before Do returns.
-func (e *EntityHandle) Do(f func(ctx *Context, e Entity)) *Task {
-	return e.schedule(func(ctx *Context, e Entity) error {
-		f(ctx, e)
+func (e *EntityHandle) Do(f func(tx *Tx, e Entity)) *Task {
+	return e.schedule(func(tx *Tx, e Entity) error {
+		f(tx, e)
 		return nil
 	})
 }
 
 // DoAfter schedules f to run with the entity after delay, following the
 // entity if it changes worlds in the meantime.
-func (e *EntityHandle) DoAfter(delay time.Duration, f func(ctx *Context, e Entity)) *Task {
-	return e.scheduleAfter(delay, func(ctx *Context, e Entity) error {
-		f(ctx, e)
+func (e *EntityHandle) DoAfter(delay time.Duration, f func(tx *Tx, e Entity)) *Task {
+	return e.scheduleAfter(delay, func(tx *Tx, e Entity) error {
+		f(tx, e)
 		return nil
 	})
 }
@@ -26,7 +26,7 @@ func (e *EntityHandle) DoAfter(delay time.Duration, f func(ctx *Context, e Entit
 // waits for the entity to be world-bound. It deliberately never enqueues onto
 // the current world directly: that would commit to one world and fail instead
 // of following the entity when it migrates.
-func (e *EntityHandle) schedule(f func(ctx *Context, e Entity) error) *Task {
+func (e *EntityHandle) schedule(f func(tx *Tx, e Entity) error) *Task {
 	task := newTask()
 	if e == nil {
 		task.failIfPending(ErrEntityClosed)
@@ -54,7 +54,7 @@ func (e *EntityHandle) schedule(f func(ctx *Context, e Entity) error) *Task {
 // scheduleAfter runs its own timer loop instead of reusing World.DoAfter:
 // the entity may change worlds during the delay, so the loop re-reads the
 // current world's signals every iteration.
-func (e *EntityHandle) scheduleAfter(delay time.Duration, f func(ctx *Context, e Entity) error) *Task {
+func (e *EntityHandle) scheduleAfter(delay time.Duration, f func(tx *Tx, e Entity) error) *Task {
 	if delay <= 0 {
 		return e.schedule(f)
 	}
@@ -160,13 +160,13 @@ func (e *EntityHandle) currentWorldClosing() bool {
 // runScheduled executes the scheduled entity callback via execWorld with the
 // same completion model as scheduledTransaction: run, drain deferred work,
 // finish the task.
-func (e *EntityHandle) runScheduled(task *Task, f func(ctx *Context, e Entity) error, allowedCloseWorld *World) {
-	run := e.execWorld(func(ctx *Context, ent Entity) {
+func (e *EntityHandle) runScheduled(task *Task, f func(tx *Tx, e Entity) error, allowedCloseWorld *World) {
+	run := e.execWorld(func(tx *Tx, ent Entity) {
 		if !task.begin() {
 			return
 		}
-		err := executeWithRecovery(ctx.w, func() error { return f(ctx, ent) })
-		ctx.runDeferred()
+		err := executeWithRecovery(tx.w, func() error { return f(tx, ent) })
+		tx.runDeferred()
 		task.finish(err)
 	}, false, task.Done(), allowedCloseWorld)
 	if !run || task.pending() {

--- a/server/world/handler.go
+++ b/server/world/handler.go
@@ -50,13 +50,11 @@ type Handler interface {
 	// ctx.Cancel() may be called to prevent leaves from decaying.
 	HandleLeavesDecay(ctx *Context, pos cube.Pos)
 	// HandleEntitySpawn handles an Entity being spawned into a World through a
-	// call to Context.AddEntity. The spawn cannot be prevented: ctx.Cancel()
-	// has no effect.
-	HandleEntitySpawn(ctx *Context, e Entity)
+	// call to Tx.AddEntity.
+	HandleEntitySpawn(tx *Tx, e Entity)
 	// HandleEntityDespawn handles an Entity being despawned from a World
-	// through a call to Context.RemoveEntity. The despawn cannot be prevented:
-	// ctx.Cancel() has no effect.
-	HandleEntityDespawn(ctx *Context, e Entity)
+	// through a call to Tx.RemoveEntity.
+	HandleEntityDespawn(tx *Tx, e Entity)
 	// HandleExplosion handles an explosion in the world. ctx.Cancel() may be called
 	// to cancel the explosion.
 	// The affected entities, affected blocks, item drop chance, and whether the
@@ -68,9 +66,8 @@ type Handler interface {
 	// HandleClose handles the World being closed. HandleClose may be used as a
 	// moment to finish code running on other goroutines that operates on the
 	// World specifically. HandleClose is called directly before the World stops
-	// ticking and before any chunks are saved to disk. The close cannot be
-	// prevented: ctx.Cancel() has no effect.
-	HandleClose(ctx *Context)
+	// ticking and before any chunks are saved to disk.
+	HandleClose(tx *Tx)
 }
 
 // Compile time check to make sure NopHandler implements Handler.
@@ -89,8 +86,8 @@ func (NopHandler) HandleFireSpread(*Context, cube.Pos, cube.Pos)                
 func (NopHandler) HandleBlockBurn(*Context, cube.Pos)                                            {}
 func (NopHandler) HandleCropTrample(*Context, cube.Pos)                                          {}
 func (NopHandler) HandleLeavesDecay(*Context, cube.Pos)                                          {}
-func (NopHandler) HandleEntitySpawn(*Context, Entity)                                            {}
-func (NopHandler) HandleEntityDespawn(*Context, Entity)                                          {}
+func (NopHandler) HandleEntitySpawn(*Tx, Entity)                                                 {}
+func (NopHandler) HandleEntityDespawn(*Tx, Entity)                                               {}
 func (NopHandler) HandleExplosion(*Context, mgl64.Vec3, *[]Entity, *[]cube.Pos, *float64, *bool) {}
 func (NopHandler) HandleRedstoneUpdate(*Context, cube.Pos)                                       {}
-func (NopHandler) HandleClose(*Context)                                                          {}
+func (NopHandler) HandleClose(*Tx)                                                               {}

--- a/server/world/handler.go
+++ b/server/world/handler.go
@@ -2,11 +2,8 @@ package world
 
 import (
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/event"
 	"github.com/go-gl/mathgl/mgl64"
 )
-
-type Context = event.Context[*Tx]
 
 // Handler handles events that are called by a world. Implementations of
 // Handler may be used to listen to specific events such as when an Entity is
@@ -53,11 +50,13 @@ type Handler interface {
 	// ctx.Cancel() may be called to prevent leaves from decaying.
 	HandleLeavesDecay(ctx *Context, pos cube.Pos)
 	// HandleEntitySpawn handles an Entity being spawned into a World through a
-	// call to Tx.AddEntity.
-	HandleEntitySpawn(tx *Tx, e Entity)
+	// call to Context.AddEntity. The spawn cannot be prevented: ctx.Cancel()
+	// has no effect.
+	HandleEntitySpawn(ctx *Context, e Entity)
 	// HandleEntityDespawn handles an Entity being despawned from a World
-	// through a call to Tx.RemoveEntity.
-	HandleEntityDespawn(tx *Tx, e Entity)
+	// through a call to Context.RemoveEntity. The despawn cannot be prevented:
+	// ctx.Cancel() has no effect.
+	HandleEntityDespawn(ctx *Context, e Entity)
 	// HandleExplosion handles an explosion in the world. ctx.Cancel() may be called
 	// to cancel the explosion.
 	// The affected entities, affected blocks, item drop chance, and whether the
@@ -69,8 +68,9 @@ type Handler interface {
 	// HandleClose handles the World being closed. HandleClose may be used as a
 	// moment to finish code running on other goroutines that operates on the
 	// World specifically. HandleClose is called directly before the World stops
-	// ticking and before any chunks are saved to disk.
-	HandleClose(tx *Tx)
+	// ticking and before any chunks are saved to disk. The close cannot be
+	// prevented: ctx.Cancel() has no effect.
+	HandleClose(ctx *Context)
 }
 
 // Compile time check to make sure NopHandler implements Handler.
@@ -89,8 +89,8 @@ func (NopHandler) HandleFireSpread(*Context, cube.Pos, cube.Pos)                
 func (NopHandler) HandleBlockBurn(*Context, cube.Pos)                                            {}
 func (NopHandler) HandleCropTrample(*Context, cube.Pos)                                          {}
 func (NopHandler) HandleLeavesDecay(*Context, cube.Pos)                                          {}
-func (NopHandler) HandleEntitySpawn(*Tx, Entity)                                                 {}
-func (NopHandler) HandleEntityDespawn(*Tx, Entity)                                               {}
+func (NopHandler) HandleEntitySpawn(*Context, Entity)                                            {}
+func (NopHandler) HandleEntityDespawn(*Context, Entity)                                          {}
 func (NopHandler) HandleExplosion(*Context, mgl64.Vec3, *[]Entity, *[]cube.Pos, *float64, *bool) {}
 func (NopHandler) HandleRedstoneUpdate(*Context, cube.Pos)                                       {}
-func (NopHandler) HandleClose(*Tx)                                                               {}
+func (NopHandler) HandleClose(*Context)                                                          {}

--- a/server/world/loader.go
+++ b/server/world/loader.go
@@ -42,12 +42,12 @@ func (l *Loader) World() *World {
 
 // ChangeWorld changes the World of the Loader. The currently loaded chunks are reset and any future loading
 // is done from the new World.
-func (l *Loader) ChangeWorld(tx *Context, new *World) {
+func (l *Loader) ChangeWorld(tx *Tx, new *World) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	loaded := maps.Clone(l.loaded)
-	l.w.exec(func(tx *Context) {
+	l.w.exec(func(tx *Tx) {
 		for pos := range loaded {
 			tx.World().removeViewer(tx, pos, l)
 		}
@@ -61,7 +61,7 @@ func (l *Loader) ChangeWorld(tx *Context, new *World) {
 }
 
 // ChangeRadius changes the maximum chunk radius of the Loader.
-func (l *Loader) ChangeRadius(tx *Context, new int) {
+func (l *Loader) ChangeRadius(tx *Tx, new int) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -71,7 +71,7 @@ func (l *Loader) ChangeRadius(tx *Context, new int) {
 }
 
 // Move moves the loader to the position passed. The position is translated to a chunk position to load
-func (l *Loader) Move(tx *Context, pos mgl64.Vec3) {
+func (l *Loader) Move(tx *Tx, pos mgl64.Vec3) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -87,7 +87,7 @@ func (l *Loader) Move(tx *Context, pos mgl64.Vec3) {
 // Load loads n chunks around the centre of the chunk, starting with the middle and working outwards. For
 // every chunk loaded, the Viewer passed through construction in New has its ViewChunk method called.
 // Load does nothing for n <= 0.
-func (l *Loader) Load(tx *Context, n int) {
+func (l *Loader) Load(tx *Tx, n int) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -124,7 +124,7 @@ func (l *Loader) Chunk(pos ChunkPos) (*Column, bool) {
 
 // Close closes the loader. It unloads all chunks currently loaded for the viewer, and hides all entities that
 // are currently shown to it.
-func (l *Loader) Close(tx *Context) {
+func (l *Loader) Close(tx *Tx) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -151,7 +151,7 @@ func (l *Loader) world(new *World) {
 
 // evictUnused gets rid of chunks in the loaded map which are no longer within the chunk radius of the loader,
 // and should therefore be removed.
-func (l *Loader) evictUnused(tx *Context) {
+func (l *Loader) evictUnused(tx *Tx) {
 	for pos := range l.loaded {
 		diffX, diffZ := pos[0]-l.pos[0], pos[1]-l.pos[1]
 		dist := math.Sqrt(float64(diffX*diffX) + float64(diffZ*diffZ))

--- a/server/world/loader.go
+++ b/server/world/loader.go
@@ -42,12 +42,12 @@ func (l *Loader) World() *World {
 
 // ChangeWorld changes the World of the Loader. The currently loaded chunks are reset and any future loading
 // is done from the new World.
-func (l *Loader) ChangeWorld(tx *Tx, new *World) {
+func (l *Loader) ChangeWorld(tx *Context, new *World) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	loaded := maps.Clone(l.loaded)
-	l.w.Exec(func(tx *Tx) {
+	l.w.exec(func(tx *Context) {
 		for pos := range loaded {
 			tx.World().removeViewer(tx, pos, l)
 		}
@@ -61,7 +61,7 @@ func (l *Loader) ChangeWorld(tx *Tx, new *World) {
 }
 
 // ChangeRadius changes the maximum chunk radius of the Loader.
-func (l *Loader) ChangeRadius(tx *Tx, new int) {
+func (l *Loader) ChangeRadius(tx *Context, new int) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -71,7 +71,7 @@ func (l *Loader) ChangeRadius(tx *Tx, new int) {
 }
 
 // Move moves the loader to the position passed. The position is translated to a chunk position to load
-func (l *Loader) Move(tx *Tx, pos mgl64.Vec3) {
+func (l *Loader) Move(tx *Context, pos mgl64.Vec3) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -87,7 +87,7 @@ func (l *Loader) Move(tx *Tx, pos mgl64.Vec3) {
 // Load loads n chunks around the centre of the chunk, starting with the middle and working outwards. For
 // every chunk loaded, the Viewer passed through construction in New has its ViewChunk method called.
 // Load does nothing for n <= 0.
-func (l *Loader) Load(tx *Tx, n int) {
+func (l *Loader) Load(tx *Context, n int) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -124,7 +124,7 @@ func (l *Loader) Chunk(pos ChunkPos) (*Column, bool) {
 
 // Close closes the loader. It unloads all chunks currently loaded for the viewer, and hides all entities that
 // are currently shown to it.
-func (l *Loader) Close(tx *Tx) {
+func (l *Loader) Close(tx *Context) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -151,7 +151,7 @@ func (l *Loader) world(new *World) {
 
 // evictUnused gets rid of chunks in the loaded map which are no longer within the chunk radius of the loader,
 // and should therefore be removed.
-func (l *Loader) evictUnused(tx *Tx) {
+func (l *Loader) evictUnused(tx *Context) {
 	for pos := range l.loaded {
 		diffX, diffZ := pos[0]-l.pos[0], pos[1]-l.pos[1]
 		dist := math.Sqrt(float64(diffX*diffX) + float64(diffZ*diffZ))

--- a/server/world/sleep.go
+++ b/server/world/sleep.go
@@ -32,7 +32,7 @@ const (
 
 // tryAdvanceDay attempts to advance the day of the world, by first ensuring that all sleepers are sleeping, and then
 // updating the time of day.
-func (ticker) tryAdvanceDay(tx *Context, timeCycle bool) {
+func (ticker) tryAdvanceDay(tx *Tx, timeCycle bool) {
 	sleepers := tx.Sleepers()
 	time := tx.w.Time() % TimeFull
 

--- a/server/world/sleep.go
+++ b/server/world/sleep.go
@@ -32,7 +32,7 @@ const (
 
 // tryAdvanceDay attempts to advance the day of the world, by first ensuring that all sleepers are sleeping, and then
 // updating the time of day.
-func (ticker) tryAdvanceDay(tx *Tx, timeCycle bool) {
+func (ticker) tryAdvanceDay(tx *Context, timeCycle bool) {
 	sleepers := tx.Sleepers()
 	time := tx.w.Time() % TimeFull
 

--- a/server/world/task.go
+++ b/server/world/task.go
@@ -15,6 +15,8 @@ var (
 	ErrWorldClosed = errors.New("world: world closed")
 	// ErrEntityClosed means the entity closed before the task could run.
 	ErrEntityClosed = errors.New("world: entity closed")
+	// ErrEntityNotInWorld means an entity was not in the transaction's world.
+	ErrEntityNotInWorld = errors.New("world: entity not in this world")
 	// ErrTaskCancelled means the task was cancelled before it started.
 	ErrTaskCancelled = errors.New("world: scheduled task cancelled")
 	// ErrTaskPanicked means the task's callback panicked; see PanicError.
@@ -42,7 +44,9 @@ func (e *PanicError) Error() string {
 func (e *PanicError) Unwrap() error { return ErrTaskPanicked }
 
 // RethrowPanic re-panics with the original panic value if err wraps a
-// *PanicError. It does nothing for any other error, including nil.
+// *PanicError. The original goroutine's stack remains in PanicError.Stack and
+// is logged through the World's Logger when recovered. RethrowPanic does
+// nothing for any other error, including nil.
 func RethrowPanic(err error) {
 	if pe, ok := errors.AsType[*PanicError](err); ok {
 		panic(pe.Value)
@@ -95,7 +99,8 @@ const (
 
 // Task tracks work scheduled onto a world or entity owner. Tasks are usually
 // fire-and-forget: Done, Err and Wait are for code running off the owner,
-// such as tests and shutdown paths.
+// such as tests and shutdown paths. A zero-value Task behaves like a cancelled
+// task.
 type Task struct {
 	done  chan struct{}
 	state atomic.Int32
@@ -129,7 +134,7 @@ var closedDone = func() <-chan struct{} {
 // Done returns a channel that closes once the task has run, failed or been
 // cancelled.
 func (t *Task) Done() <-chan struct{} {
-	if t == nil {
+	if t == nil || t.done == nil {
 		return closedDone
 	}
 	return t.done
@@ -138,7 +143,7 @@ func (t *Task) Done() <-chan struct{} {
 // Err returns the task's error, or nil while the task is still pending or
 // after it succeeded.
 func (t *Task) Err() error {
-	if t == nil {
+	if t == nil || t.done == nil {
 		return ErrTaskCancelled
 	}
 	select {
@@ -158,7 +163,7 @@ func (t *Task) Wait(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if t == nil {
+	if t == nil || t.done == nil {
 		return ErrTaskCancelled
 	}
 	select {
@@ -170,10 +175,11 @@ func (t *Task) Wait(ctx context.Context) error {
 }
 
 // OnDone calls f with the task's error on a fresh goroutine once the task
-// completes. For a nil task, f runs immediately with ErrTaskCancelled.
+// completes. Nil and zero-value tasks call f with ErrTaskCancelled. The
+// callback always runs on a fresh goroutine, including for those tasks.
 func (t *Task) OnDone(f func(err error)) {
-	if t == nil {
-		f(ErrTaskCancelled)
+	if t == nil || t.done == nil {
+		go f(ErrTaskCancelled)
 		return
 	}
 	go func() {
@@ -185,7 +191,7 @@ func (t *Task) OnDone(f func(err error)) {
 // Cancel stops a task that has not started yet, reporting whether it did:
 // true means the task will never run.
 func (t *Task) Cancel() bool {
-	if t == nil || !t.state.CompareAndSwap(taskPending, taskCancelled) {
+	if t == nil || t.done == nil || !t.state.CompareAndSwap(taskPending, taskCancelled) {
 		return false
 	}
 	t.setErr(ErrTaskCancelled)
@@ -254,22 +260,23 @@ func (t *Task) runCancel() {
 }
 
 // Do schedules f to run on the world owner and returns immediately; it is
-// safe to call from anywhere, including owner callbacks. Work runs in FIFO
-// order once queued, though a full queue can delay enqueueing. On a
-// synchronous World, f runs before Do returns.
-func (w *World) Do(f func(ctx *Context)) *Task {
-	return w.scheduleTask(newTask(), func(ctx *Context) error {
-		f(ctx)
+// safe to call from anywhere, including owner callbacks. Tasks usually run in
+// submission order, but ordering is not guaranteed between tasks scheduled
+// while the queue is saturated. Use one task or Tx.Defer for strictly ordered
+// work. On a synchronous World, f runs before Do returns.
+func (w *World) Do(f func(tx *Tx)) *Task {
+	return w.scheduleTask(newTask(), func(tx *Tx) error {
+		f(tx)
 		return nil
 	})
 }
 
 // DoAfter schedules f to run on the world owner after delay. Cancelling the
 // task before delay elapses stops f from being queued at all.
-func (w *World) DoAfter(delay time.Duration, f func(ctx *Context)) *Task {
+func (w *World) DoAfter(delay time.Duration, f func(tx *Tx)) *Task {
 	t := newTask()
-	run := func(ctx *Context) error {
-		f(ctx)
+	run := func(tx *Tx) error {
+		f(tx)
 		return nil
 	}
 	if delay <= 0 {
@@ -299,32 +306,36 @@ func (w *World) DoAfter(delay time.Duration, f func(ctx *Context)) *Task {
 
 // Call runs f on w's owner and waits for its typed result. It is for
 // off-owner code such as tests, startup and background goroutines; if you
-// already have a *world.Context, just use it directly. Calling it from the
-// owner itself (any scheduled callback or Handler event) deadlocks.
-func Call[T any](ctx context.Context, w *World, f func(ctx *Context) (T, error)) (T, error) {
+// already have a *world.Tx, just use it directly. Calling it from the
+// owner itself (any scheduled callback or Handler event) deadlocks. A panic in
+// f is recovered and returned as a *PanicError matching ErrTaskPanicked; call
+// RethrowPanic to restore panic semantics.
+func Call[T any](ctx context.Context, w *World, f func(tx *Tx) (T, error)) (T, error) {
 	var zero T
 	ctx, err := callContext(ctx)
 	if err != nil {
 		return zero, err
 	}
 	var result T
-	task := w.scheduleTask(newTask(), func(wctx *Context) error {
+	task := w.scheduleTask(newTask(), func(tx *Tx) error {
 		var err error
-		result, err = f(wctx)
+		result, err = f(tx)
 		return err
 	})
 	return awaitTask(ctx, task, &result)
 }
 
 // CallEntity runs f with the EntityHandle's entity on its current world owner
-// and waits for the typed result. Off-owner code only, like Call.
-func CallEntity[R any](ctx context.Context, h *EntityHandle, f func(ctx *Context, e Entity) (R, error)) (R, error) {
+// and waits for the typed result. Off-owner code only, like Call. A panic in f
+// is recovered and returned as a *PanicError matching ErrTaskPanicked; call
+// RethrowPanic to restore panic semantics.
+func CallEntity[T any](ctx context.Context, h *EntityHandle, f func(tx *Tx, e Entity) (T, error)) (T, error) {
 	return CallRef(ctx, NewEntityRef[Entity](h), f)
 }
 
 // scheduleTask enqueues a scheduledTransaction on the world's owner queue,
 // handing a full queue off to a helper goroutine rather than blocking.
-func (w *World) scheduleTask(task *Task, f func(ctx *Context) error) *Task {
+func (w *World) scheduleTask(task *Task, f func(tx *Tx) error) *Task {
 	if task == nil {
 		task = newTask()
 	}
@@ -379,12 +390,12 @@ func (w *World) queueScheduled(st scheduledTransaction) {
 	}
 }
 
-// scheduledTransaction is a queued task from Do, DoAfter or Context.Defer: it
+// scheduledTransaction is a queued task from Do, DoAfter or Tx.Defer: it
 // runs the callback with panic recovery, drains deferred work and finishes the
 // task.
 type scheduledTransaction struct {
 	task *Task
-	f    func(ctx *Context) error
+	f    func(tx *Tx) error
 }
 
 // Run executes the scheduled callback on the world goroutine.
@@ -392,9 +403,9 @@ func (st scheduledTransaction) Run(w *World) {
 	if !st.task.begin() {
 		return
 	}
-	ctx := newContext(w)
-	err := executeWithRecovery(w, func() error { return st.f(ctx) })
-	ctx.close()
-	ctx.runDeferred()
+	tx := newTx(w)
+	err := executeWithRecovery(w, func() error { return st.f(tx) })
+	tx.close()
+	tx.runDeferred()
 	st.task.finish(err)
 }

--- a/server/world/task.go
+++ b/server/world/task.go
@@ -1,0 +1,400 @@
+package world
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	// ErrWorldClosed means the task's world closed before the task could run.
+	ErrWorldClosed = errors.New("world: world closed")
+	// ErrEntityClosed means the entity closed before the task could run.
+	ErrEntityClosed = errors.New("world: entity closed")
+	// ErrTaskCancelled means the task was cancelled before it started.
+	ErrTaskCancelled = errors.New("world: scheduled task cancelled")
+	// ErrTaskPanicked means the task's callback panicked; see PanicError.
+	ErrTaskPanicked = errors.New("world: scheduled task panicked")
+	// ErrEntityType means the entity no longer had the type expected by a
+	// typed EntityRef when the task ran.
+	ErrEntityType = errors.New("world: unexpected entity type")
+)
+
+// PanicError is the Task error for a callback that panicked. It matches
+// errors.Is(err, ErrTaskPanicked) and keeps the original panic value and stack.
+type PanicError struct {
+	// Value is the recovered panic value.
+	Value any
+	// Stack is the stack of the panicking goroutine.
+	Stack []byte
+}
+
+// Error implements the error interface.
+func (e *PanicError) Error() string {
+	return fmt.Sprintf("world: scheduled task panicked: %v", e.Value)
+}
+
+// Unwrap returns ErrTaskPanicked so errors.Is works.
+func (e *PanicError) Unwrap() error { return ErrTaskPanicked }
+
+// RethrowPanic re-panics with the original panic value if err wraps a
+// *PanicError. It does nothing for any other error, including nil.
+func RethrowPanic(err error) {
+	if pe, ok := errors.AsType[*PanicError](err); ok {
+		panic(pe.Value)
+	}
+}
+
+// callContext normalises a possibly-nil caller context and reports whether it
+// was cancelled before any work was scheduled.
+func callContext(ctx context.Context) (context.Context, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return ctx, ctx.Err()
+}
+
+// executeWithRecovery runs f, recovering and logging any panic through w.
+func executeWithRecovery(w *World, f func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicErr := &PanicError{Value: r, Stack: debug.Stack()}
+			w.conf.Log.Error("scheduled task panicked", "panic", panicErr.Value, "stack", string(panicErr.Stack))
+			err = panicErr
+		}
+	}()
+	return f()
+}
+
+// awaitTask waits for a task to complete or the context to cancel, returning
+// the result stored by the callback through the result pointer.
+func awaitTask[T any](ctx context.Context, task *Task, result *T) (T, error) {
+	var zero T
+	select {
+	case <-task.Done():
+		if err := task.Err(); err != nil {
+			return zero, err
+		}
+		return *result, nil
+	case <-ctx.Done():
+		task.Cancel()
+		return zero, ctx.Err()
+	}
+}
+
+const (
+	taskPending int32 = iota
+	taskRunning
+	taskDone
+	taskCancelled
+)
+
+// Task tracks work scheduled onto a world or entity owner. Tasks are usually
+// fire-and-forget: Done, Err and Wait are for code running off the owner,
+// such as tests and shutdown paths.
+type Task struct {
+	done  chan struct{}
+	state atomic.Int32
+
+	errMu sync.Mutex
+	err   error
+
+	cancelMu sync.Mutex
+	onCancel func()
+}
+
+// newTask returns a pending Task with an open done channel.
+func newTask() *Task {
+	return &Task{done: make(chan struct{})}
+}
+
+// NewFinishedTask returns a Task that already completed with err.
+func NewFinishedTask(err error) *Task {
+	t := newTask()
+	t.failIfPending(err)
+	return t
+}
+
+// closedDone is the Done channel returned for nil tasks.
+var closedDone = func() <-chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}()
+
+// Done returns a channel that closes once the task has run, failed or been
+// cancelled.
+func (t *Task) Done() <-chan struct{} {
+	if t == nil {
+		return closedDone
+	}
+	return t.done
+}
+
+// Err returns the task's error, or nil while the task is still pending or
+// after it succeeded.
+func (t *Task) Err() error {
+	if t == nil {
+		return ErrTaskCancelled
+	}
+	select {
+	case <-t.done:
+		t.errMu.Lock()
+		defer t.errMu.Unlock()
+		return t.err
+	default:
+		return nil
+	}
+}
+
+// Wait blocks until the task finishes or ctx is cancelled. Never call it from
+// a callback running on the same owner: that blocks the owner on itself, the
+// deadlock Do exists to avoid.
+func (t *Task) Wait(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if t == nil {
+		return ErrTaskCancelled
+	}
+	select {
+	case <-t.done:
+		return t.Err()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// OnDone calls f with the task's error on a fresh goroutine once the task
+// completes. For a nil task, f runs immediately with ErrTaskCancelled.
+func (t *Task) OnDone(f func(err error)) {
+	if t == nil {
+		f(ErrTaskCancelled)
+		return
+	}
+	go func() {
+		<-t.done
+		f(t.Err())
+	}()
+}
+
+// Cancel stops a task that has not started yet, reporting whether it did:
+// true means the task will never run.
+func (t *Task) Cancel() bool {
+	if t == nil || !t.state.CompareAndSwap(taskPending, taskCancelled) {
+		return false
+	}
+	t.setErr(ErrTaskCancelled)
+	close(t.done)
+	t.runCancel()
+	return true
+}
+
+// begin moves the task from pending to running, reporting whether it did.
+func (t *Task) begin() bool {
+	return t != nil && t.state.CompareAndSwap(taskPending, taskRunning)
+}
+
+// failIfPending completes a still-pending task with err, reporting whether it
+// did.
+func (t *Task) failIfPending(err error) bool {
+	if t == nil || !t.state.CompareAndSwap(taskPending, taskRunning) {
+		return false
+	}
+	t.finish(err)
+	return true
+}
+
+// finish completes the task, storing err and closing the done channel.
+func (t *Task) finish(err error) {
+	t.setErr(err)
+	t.state.Store(taskDone)
+	close(t.done)
+}
+
+func (t *Task) setErr(err error) {
+	t.errMu.Lock()
+	t.err = err
+	t.errMu.Unlock()
+}
+
+func (t *Task) pending() bool {
+	return t != nil && t.state.Load() == taskPending
+}
+
+// setCancel registers a function to run if the task is cancelled. If the
+// task is already cancelled when setCancel is called, f runs immediately.
+func (t *Task) setCancel(f func()) {
+	if t == nil || f == nil {
+		return
+	}
+	t.cancelMu.Lock()
+	cancelled := t.state.Load() == taskCancelled
+	if !cancelled {
+		t.onCancel = f
+	}
+	t.cancelMu.Unlock()
+	if cancelled {
+		f()
+	}
+}
+
+// runCancel invokes the registered cancel function, if any.
+func (t *Task) runCancel() {
+	t.cancelMu.Lock()
+	f := t.onCancel
+	t.cancelMu.Unlock()
+	if f != nil {
+		f()
+	}
+}
+
+// Do schedules f to run on the world owner and returns immediately; it is
+// safe to call from anywhere, including owner callbacks. Work runs in FIFO
+// order once queued, though a full queue can delay enqueueing. On a
+// synchronous World, f runs before Do returns.
+func (w *World) Do(f func(ctx *Context)) *Task {
+	return w.scheduleTask(newTask(), func(ctx *Context) error {
+		f(ctx)
+		return nil
+	})
+}
+
+// DoAfter schedules f to run on the world owner after delay. Cancelling the
+// task before delay elapses stops f from being queued at all.
+func (w *World) DoAfter(delay time.Duration, f func(ctx *Context)) *Task {
+	t := newTask()
+	run := func(ctx *Context) error {
+		f(ctx)
+		return nil
+	}
+	if delay <= 0 {
+		return w.scheduleTask(t, run)
+	}
+	if w == nil || w.queue == nil || w.closed.Load() {
+		t.failIfPending(ErrWorldClosed)
+		return t
+	}
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			w.scheduleTask(t, run)
+		case <-t.Done():
+		case <-w.closeStarted:
+			t.failIfPending(ErrWorldClosed)
+		case <-w.closing:
+			t.failIfPending(ErrWorldClosed)
+		case <-w.queueClosing:
+			t.failIfPending(ErrWorldClosed)
+		}
+	}()
+	return t
+}
+
+// Call runs f on w's owner and waits for its typed result. It is for
+// off-owner code such as tests, startup and background goroutines; if you
+// already have a *world.Context, just use it directly. Calling it from the
+// owner itself (any scheduled callback or Handler event) deadlocks.
+func Call[T any](ctx context.Context, w *World, f func(ctx *Context) (T, error)) (T, error) {
+	var zero T
+	ctx, err := callContext(ctx)
+	if err != nil {
+		return zero, err
+	}
+	var result T
+	task := w.scheduleTask(newTask(), func(wctx *Context) error {
+		var err error
+		result, err = f(wctx)
+		return err
+	})
+	return awaitTask(ctx, task, &result)
+}
+
+// CallEntity runs f with the EntityHandle's entity on its current world owner
+// and waits for the typed result. Off-owner code only, like Call.
+func CallEntity[R any](ctx context.Context, h *EntityHandle, f func(ctx *Context, e Entity) (R, error)) (R, error) {
+	return CallRef(ctx, NewEntityRef[Entity](h), f)
+}
+
+// scheduleTask enqueues a scheduledTransaction on the world's owner queue,
+// handing a full queue off to a helper goroutine rather than blocking.
+func (w *World) scheduleTask(task *Task, f func(ctx *Context) error) *Task {
+	if task == nil {
+		task = newTask()
+	}
+	if w == nil || w.queue == nil || w.closed.Load() {
+		task.failIfPending(ErrWorldClosed)
+		return task
+	}
+	if !task.pending() {
+		return task
+	}
+	st := scheduledTransaction{task: task, f: f}
+	w.scheduleMu.Lock()
+	if w.closed.Load() {
+		w.scheduleMu.Unlock()
+		task.failIfPending(ErrWorldClosed)
+		return task
+	}
+	if w.conf.Synchronous {
+		w.scheduleMu.Unlock()
+		st.Run(w)
+		return task
+	}
+	select {
+	case <-w.closing:
+		task.failIfPending(ErrWorldClosed)
+	case <-w.queueClosing:
+		task.failIfPending(ErrWorldClosed)
+	case w.queue <- st:
+	default:
+		w.scheduling.Add(1)
+		go w.queueScheduled(st)
+	}
+	w.scheduleMu.Unlock()
+	return task
+}
+
+// queueScheduled retries enqueuing st once the queue, full at schedule time,
+// has room, failing the task if the world closes first.
+func (w *World) queueScheduled(st scheduledTransaction) {
+	defer w.scheduling.Done()
+	if w.closed.Load() {
+		st.task.failIfPending(ErrWorldClosed)
+		return
+	}
+	select {
+	case <-w.closing:
+		st.task.failIfPending(ErrWorldClosed)
+	case <-w.queueClosing:
+		st.task.failIfPending(ErrWorldClosed)
+	case <-st.task.Done():
+	case w.queue <- st:
+	}
+}
+
+// scheduledTransaction is a queued task from Do, DoAfter or Context.Defer: it
+// runs the callback with panic recovery, drains deferred work and finishes the
+// task.
+type scheduledTransaction struct {
+	task *Task
+	f    func(ctx *Context) error
+}
+
+// Run executes the scheduled callback on the world goroutine.
+func (st scheduledTransaction) Run(w *World) {
+	if !st.task.begin() {
+		return
+	}
+	ctx := newContext(w)
+	err := executeWithRecovery(w, func() error { return st.f(ctx) })
+	ctx.close()
+	ctx.runDeferred()
+	st.task.finish(err)
+}

--- a/server/world/task_test.go
+++ b/server/world/task_test.go
@@ -1,0 +1,303 @@
+package world
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/go-gl/mathgl/mgl64"
+)
+
+func TestEntityDoCancelAfterInvalidatedWeakTransactionDoesNotPoisonHandle(t *testing.T) {
+	w := New()
+	defer w.Close()
+
+	h := NewEntity(taskTestEntityType{}, taskTestEntityConfig{})
+	<-w.exec(func(tx *Context) { tx.AddEntity(h) })
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	w.exec(func(*Context) {
+		close(started)
+		<-release
+	})
+	<-started
+
+	removeDone := w.exec(func(tx *Context) {
+		e, ok := h.Entity(tx)
+		if !ok {
+			t.Error("entity missing before remove")
+			return
+		}
+		tx.RemoveEntity(e)
+	})
+	task := h.Do(func(*Context, Entity) {
+		t.Error("cancelled task ran")
+	})
+	// The fast path in schedule may queue directly without a weak
+	// transaction. Either way, the task must still be cancellable while
+	// pending.
+	if !task.Cancel() {
+		t.Fatal("expected pending task to cancel")
+	}
+	close(release)
+	<-removeDone
+	if err := task.Wait(testContext(t)); !errors.Is(err, ErrTaskCancelled) {
+		t.Fatalf("expected ErrTaskCancelled, got %v", err)
+	}
+
+	<-w.exec(func(tx *Context) { tx.AddEntity(h) })
+	task = h.Do(func(*Context, Entity) {})
+	if err := task.Wait(testContext(t)); err != nil {
+		t.Fatalf("handle poisoned after cancelling invalidated weak transaction: %v", err)
+	}
+}
+
+func TestDoDoesNotBlockOwnerWhenQueueFull(t *testing.T) {
+	w := New()
+	defer w.Close()
+
+	done := make(chan struct{})
+	go func() {
+		<-w.exec(func(tx *Context) {
+			for i := 0; i < cap(w.queue)+32; i++ {
+				w.Do(func(*Context) {})
+				tx.Defer(func(*Context) {})
+			}
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Do or Context.Defer blocked the world owner")
+	}
+}
+
+// TestWeakExecDoesNotBlockOwnerWhenQueueFull ensures an off-owner weak
+// transaction blocked on a full queue does not hold scheduleMu, which would
+
+func TestWeakExecDoesNotBlockOwnerWhenQueueFull(t *testing.T) {
+	w := New()
+
+	h := NewEntity(taskTestEntityType{}, taskTestEntityConfig{})
+	<-w.exec(func(tx *Context) { tx.AddEntity(h) })
+
+	entered := make(chan struct{})
+	proceed := make(chan struct{})
+	release := make(chan struct{})
+
+	// Occupy the world owner goroutine.
+	w.exec(func(tx *Context) {
+		close(entered)
+		<-proceed
+		// Owner-side fire-and-forget must not block on scheduleMu.
+		w.Do(func(ctx *Context) {})
+		close(release)
+	})
+	<-entered
+
+	// Fill the queue to capacity while the owner is busy.
+	for i := 0; i < cap(w.queue); i++ {
+		w.queue <- normalTransaction{c: make(chan struct{}), f: func(tx *Context) {}}
+	}
+
+	// Entity task whose weak transaction ends up in World.weakExec with the
+	// queue full.
+	task := h.Do(func(ctx *Context, e Entity) {})
+	time.Sleep(200 * time.Millisecond)
+
+	close(proceed)
+	select {
+	case <-release:
+	case <-time.After(3 * time.Second):
+		t.Fatal("owner-side World.Do deadlocked on scheduleMu held by weakExec blocked on full queue")
+	}
+	if err := task.Wait(testContext(t)); err != nil {
+		t.Fatalf("entity task failed after queue drained: %v", err)
+	}
+	_ = w.Close()
+}
+
+func TestDoQueuedBeforeCloseDoesNotRunAfterHandleClose(t *testing.T) {
+	w := New()
+
+	var closeHandled atomic.Bool
+	var ranAfterClose atomic.Bool
+	w.Handle(closeOrderHandler{closed: &closeHandled})
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	w.exec(func(*Context) {
+		close(started)
+		<-release
+	})
+	<-started
+
+	for i := 0; i < cap(w.queue); i++ {
+		w.exec(func(*Context) {})
+	}
+	task := w.Do(func(*Context) {
+		if closeHandled.Load() {
+			ranAfterClose.Store(true)
+		}
+	})
+
+	closed := make(chan struct{})
+	go func() {
+		_ = w.Close()
+		close(closed)
+	}()
+	close(release)
+
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("world close did not complete")
+	}
+	if err := task.Wait(testContext(t)); err != nil && !errors.Is(err, ErrWorldClosed) {
+		t.Fatalf("scheduled task failed with unexpected error: %v", err)
+	}
+	if ranAfterClose.Load() {
+		t.Fatal("scheduled task ran after HandleClose")
+	}
+}
+
+func TestEntityDoScheduledDuringWorldCloseRunsBeforeQueueShutdown(t *testing.T) {
+	var task *Task
+	w := New()
+	h := NewEntity(closeSchedulingEntityType{}, closeSchedulingEntityConfig{onClose: func(h *EntityHandle) {
+		task = h.Do(func(*Context, Entity) {})
+	}})
+	<-w.exec(func(tx *Context) { tx.AddEntity(h) })
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close world: %v", err)
+	}
+	if task == nil {
+		t.Fatal("entity close did not schedule cleanup task")
+	}
+	if err := task.Wait(testContext(t)); err != nil {
+		t.Fatalf("close-time entity task failed: %v", err)
+	}
+}
+
+func TestEntityDoBlockedBeforeWorldCloseFailsPromptly(t *testing.T) {
+	w := New()
+	h := NewEntity(closeSchedulingEntityType{}, closeSchedulingEntityConfig{})
+	<-w.exec(func(tx *Context) { tx.AddEntity(h) })
+
+	h.cond.L.Lock()
+	h.weakTxActive = true
+	h.cond.L.Unlock()
+	task := h.Do(func(*Context, Entity) {
+		t.Error("entity task ran after world close")
+	})
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close world: %v", err)
+	}
+	h.cond.L.Lock()
+	h.weakTxActive = false
+	h.cond.Broadcast()
+	h.cond.L.Unlock()
+
+	if err := task.Wait(testContext(t)); !errors.Is(err, ErrWorldClosed) {
+		t.Fatalf("expected ErrWorldClosed, got %v", err)
+	}
+}
+
+type taskTestEntityConfig struct{}
+
+type closeOrderHandler struct {
+	NopHandler
+	closed *atomic.Bool
+}
+
+func (h closeOrderHandler) HandleClose(*Context) { h.closed.Store(true) }
+
+type closeSchedulingEntityConfig struct {
+	onClose func(*EntityHandle)
+}
+
+func (c closeSchedulingEntityConfig) Apply(data *EntityData) { data.Data = c.onClose }
+
+type closeSchedulingEntityType struct{}
+
+func (closeSchedulingEntityType) Open(_ *Context, handle *EntityHandle, data *EntityData) Entity {
+	onClose, _ := data.Data.(func(*EntityHandle))
+	return closeSchedulingEntity{h: handle, onClose: onClose}
+}
+
+func (closeSchedulingEntityType) EncodeEntity() string { return "dragonfly:close_scheduling_entity" }
+
+func (closeSchedulingEntityType) BBox(Entity) cube.BBox { return cube.BBox{} }
+
+func (closeSchedulingEntityType) DecodeNBT(map[string]any, *EntityData) {}
+
+func (closeSchedulingEntityType) EncodeNBT(*EntityData) map[string]any { return nil }
+
+type closeSchedulingEntity struct {
+	h       *EntityHandle
+	onClose func(*EntityHandle)
+}
+
+func (e closeSchedulingEntity) Close() error {
+	if e.onClose != nil {
+		e.onClose(e.h)
+	}
+	return nil
+}
+
+func (e closeSchedulingEntity) H() *EntityHandle { return e.h }
+
+func (closeSchedulingEntity) Position() mgl64.Vec3 { return mgl64.Vec3{} }
+
+func (closeSchedulingEntity) Rotation() cube.Rotation { return cube.Rotation{} }
+
+func (taskTestEntityConfig) Apply(*EntityData) {}
+
+type taskTestEntityType struct{}
+
+func (taskTestEntityType) Open(tx *Context, handle *EntityHandle, _ *EntityData) Entity {
+	return taskTestEntity{h: handle, tx: tx}
+}
+
+func (taskTestEntityType) EncodeEntity() string { return "dragonfly:test_entity" }
+
+func (taskTestEntityType) BBox(Entity) cube.BBox { return cube.BBox{} }
+
+func (taskTestEntityType) DecodeNBT(map[string]any, *EntityData) {}
+
+func (taskTestEntityType) EncodeNBT(*EntityData) map[string]any { return nil }
+
+type taskTestEntity struct {
+	h  *EntityHandle
+	tx *Context
+}
+
+func (e taskTestEntity) Close() error {
+	if e.tx != nil {
+		if ent, ok := e.h.Entity(e.tx); ok {
+			e.tx.RemoveEntity(ent)
+		}
+	}
+	return e.h.Close()
+}
+
+func (e taskTestEntity) H() *EntityHandle { return e.h }
+
+func (taskTestEntity) Position() mgl64.Vec3 { return mgl64.Vec3{} }
+
+func (taskTestEntity) Rotation() cube.Rotation { return cube.Rotation{} }
+
+func testContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}

--- a/server/world/task_test.go
+++ b/server/world/task_test.go
@@ -16,17 +16,17 @@ func TestEntityDoCancelAfterInvalidatedWeakTransactionDoesNotPoisonHandle(t *tes
 	defer w.Close()
 
 	h := NewEntity(taskTestEntityType{}, taskTestEntityConfig{})
-	<-w.exec(func(tx *Context) { tx.AddEntity(h) })
+	<-w.exec(func(tx *Tx) { tx.AddEntity(h) })
 
 	started := make(chan struct{})
 	release := make(chan struct{})
-	w.exec(func(*Context) {
+	w.exec(func(*Tx) {
 		close(started)
 		<-release
 	})
 	<-started
 
-	removeDone := w.exec(func(tx *Context) {
+	removeDone := w.exec(func(tx *Tx) {
 		e, ok := h.Entity(tx)
 		if !ok {
 			t.Error("entity missing before remove")
@@ -34,7 +34,7 @@ func TestEntityDoCancelAfterInvalidatedWeakTransactionDoesNotPoisonHandle(t *tes
 		}
 		tx.RemoveEntity(e)
 	})
-	task := h.Do(func(*Context, Entity) {
+	task := h.Do(func(*Tx, Entity) {
 		t.Error("cancelled task ran")
 	})
 	// The fast path in schedule may queue directly without a weak
@@ -49,8 +49,8 @@ func TestEntityDoCancelAfterInvalidatedWeakTransactionDoesNotPoisonHandle(t *tes
 		t.Fatalf("expected ErrTaskCancelled, got %v", err)
 	}
 
-	<-w.exec(func(tx *Context) { tx.AddEntity(h) })
-	task = h.Do(func(*Context, Entity) {})
+	<-w.exec(func(tx *Tx) { tx.AddEntity(h) })
+	task = h.Do(func(*Tx, Entity) {})
 	if err := task.Wait(testContext(t)); err != nil {
 		t.Fatalf("handle poisoned after cancelling invalidated weak transaction: %v", err)
 	}
@@ -62,10 +62,10 @@ func TestDoDoesNotBlockOwnerWhenQueueFull(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		<-w.exec(func(tx *Context) {
+		<-w.exec(func(tx *Tx) {
 			for i := 0; i < cap(w.queue)+32; i++ {
-				w.Do(func(*Context) {})
-				tx.Defer(func(*Context) {})
+				w.Do(func(*Tx) {})
+				tx.Defer(func(*Tx) {})
 			}
 		})
 		close(done)
@@ -85,30 +85,30 @@ func TestWeakExecDoesNotBlockOwnerWhenQueueFull(t *testing.T) {
 	w := New()
 
 	h := NewEntity(taskTestEntityType{}, taskTestEntityConfig{})
-	<-w.exec(func(tx *Context) { tx.AddEntity(h) })
+	<-w.exec(func(tx *Tx) { tx.AddEntity(h) })
 
 	entered := make(chan struct{})
 	proceed := make(chan struct{})
 	release := make(chan struct{})
 
 	// Occupy the world owner goroutine.
-	w.exec(func(tx *Context) {
+	w.exec(func(tx *Tx) {
 		close(entered)
 		<-proceed
 		// Owner-side fire-and-forget must not block on scheduleMu.
-		w.Do(func(ctx *Context) {})
+		w.Do(func(tx *Tx) {})
 		close(release)
 	})
 	<-entered
 
 	// Fill the queue to capacity while the owner is busy.
 	for i := 0; i < cap(w.queue); i++ {
-		w.queue <- normalTransaction{c: make(chan struct{}), f: func(tx *Context) {}}
+		w.queue <- normalTransaction{c: make(chan struct{}), f: func(tx *Tx) {}}
 	}
 
 	// Entity task whose weak transaction ends up in World.weakExec with the
 	// queue full.
-	task := h.Do(func(ctx *Context, e Entity) {})
+	task := h.Do(func(tx *Tx, e Entity) {})
 	time.Sleep(200 * time.Millisecond)
 
 	close(proceed)
@@ -132,16 +132,16 @@ func TestDoQueuedBeforeCloseDoesNotRunAfterHandleClose(t *testing.T) {
 
 	started := make(chan struct{})
 	release := make(chan struct{})
-	w.exec(func(*Context) {
+	w.exec(func(*Tx) {
 		close(started)
 		<-release
 	})
 	<-started
 
 	for i := 0; i < cap(w.queue); i++ {
-		w.exec(func(*Context) {})
+		w.exec(func(*Tx) {})
 	}
-	task := w.Do(func(*Context) {
+	task := w.Do(func(*Tx) {
 		if closeHandled.Load() {
 			ranAfterClose.Store(true)
 		}
@@ -171,9 +171,9 @@ func TestEntityDoScheduledDuringWorldCloseRunsBeforeQueueShutdown(t *testing.T) 
 	var task *Task
 	w := New()
 	h := NewEntity(closeSchedulingEntityType{}, closeSchedulingEntityConfig{onClose: func(h *EntityHandle) {
-		task = h.Do(func(*Context, Entity) {})
+		task = h.Do(func(*Tx, Entity) {})
 	}})
-	<-w.exec(func(tx *Context) { tx.AddEntity(h) })
+	<-w.exec(func(tx *Tx) { tx.AddEntity(h) })
 
 	if err := w.Close(); err != nil {
 		t.Fatalf("close world: %v", err)
@@ -189,12 +189,12 @@ func TestEntityDoScheduledDuringWorldCloseRunsBeforeQueueShutdown(t *testing.T) 
 func TestEntityDoBlockedBeforeWorldCloseFailsPromptly(t *testing.T) {
 	w := New()
 	h := NewEntity(closeSchedulingEntityType{}, closeSchedulingEntityConfig{})
-	<-w.exec(func(tx *Context) { tx.AddEntity(h) })
+	<-w.exec(func(tx *Tx) { tx.AddEntity(h) })
 
 	h.cond.L.Lock()
 	h.weakTxActive = true
 	h.cond.L.Unlock()
-	task := h.Do(func(*Context, Entity) {
+	task := h.Do(func(*Tx, Entity) {
 		t.Error("entity task ran after world close")
 	})
 
@@ -218,7 +218,7 @@ type closeOrderHandler struct {
 	closed *atomic.Bool
 }
 
-func (h closeOrderHandler) HandleClose(*Context) { h.closed.Store(true) }
+func (h closeOrderHandler) HandleClose(*Tx) { h.closed.Store(true) }
 
 type closeSchedulingEntityConfig struct {
 	onClose func(*EntityHandle)
@@ -228,7 +228,7 @@ func (c closeSchedulingEntityConfig) Apply(data *EntityData) { data.Data = c.onC
 
 type closeSchedulingEntityType struct{}
 
-func (closeSchedulingEntityType) Open(_ *Context, handle *EntityHandle, data *EntityData) Entity {
+func (closeSchedulingEntityType) Open(_ *Tx, handle *EntityHandle, data *EntityData) Entity {
 	onClose, _ := data.Data.(func(*EntityHandle))
 	return closeSchedulingEntity{h: handle, onClose: onClose}
 }
@@ -263,7 +263,7 @@ func (taskTestEntityConfig) Apply(*EntityData) {}
 
 type taskTestEntityType struct{}
 
-func (taskTestEntityType) Open(tx *Context, handle *EntityHandle, _ *EntityData) Entity {
+func (taskTestEntityType) Open(tx *Tx, handle *EntityHandle, _ *EntityData) Entity {
 	return taskTestEntity{h: handle, tx: tx}
 }
 
@@ -277,7 +277,7 @@ func (taskTestEntityType) EncodeNBT(*EntityData) map[string]any { return nil }
 
 type taskTestEntity struct {
 	h  *EntityHandle
-	tx *Context
+	tx *Tx
 }
 
 func (e taskTestEntity) Close() error {

--- a/server/world/tick.go
+++ b/server/world/tick.go
@@ -43,7 +43,7 @@ func (w *World) AdvanceTick() {
 
 // tick performs a tick on the World and updates the time, weather, blocks and
 // entities that require updates.
-func (t ticker) tick(tx *Context) {
+func (t ticker) tick(tx *Tx) {
 	viewers, loaders := tx.World().allViewers()
 	w := tx.World()
 
@@ -104,7 +104,7 @@ func (t ticker) tick(tx *Context) {
 }
 
 // performNeighbourUpdates performs all block updates that came as a result of a neighbouring block being changed.
-func (t ticker) performNeighbourUpdates(tx *Context) {
+func (t ticker) performNeighbourUpdates(tx *Tx) {
 	updates := slices.Clone(tx.World().neighbourUpdates)
 	clear(tx.World().neighbourUpdates)
 	tx.World().neighbourUpdates = tx.World().neighbourUpdates[:0]
@@ -123,7 +123,7 @@ func (t ticker) performNeighbourUpdates(tx *Context) {
 }
 
 // tickBlocksRandomly executes random block ticks in loaded chunks within range of loaders.
-func (t ticker) tickBlocksRandomly(tx *Context, loaders []*Loader, tick int64) {
+func (t ticker) tickBlocksRandomly(tx *Tx, loaders []*Loader, tick int64) {
 	var (
 		r             = int32(tx.World().tickRange())
 		g             randUint4
@@ -208,7 +208,7 @@ func (t ticker) anyWithinDistance(pos ChunkPos, loaded []ChunkPos, r int32) bool
 
 // tickEntities ticks all entities in the world, making sure they are still located in the correct chunks and
 // updating where necessary.
-func (t ticker) tickEntities(tx *Context, tick int64) {
+func (t ticker) tickEntities(tx *Tx, tick int64) {
 	for handle, lastPos := range tx.World().entities {
 		e := handle.mustEntity(tx)
 		chunkPos := chunkPosFromVec3(handle.data.Pos)
@@ -305,7 +305,7 @@ func newScheduledTickQueue(tick int64) *scheduledTickQueue {
 // tick processes scheduled ticks, calling ScheduledTicker.ScheduledTick for any
 // block update that is scheduled for the tick passed, and removing it from the
 // queue.
-func (queue *scheduledTickQueue) tick(tx *Context, tick int64) {
+func (queue *scheduledTickQueue) tick(tx *Tx, tick int64) {
 	queue.currentTick = tick
 
 	w := tx.World()

--- a/server/world/tick.go
+++ b/server/world/tick.go
@@ -24,7 +24,7 @@ func (t ticker) tickLoop(w *World) {
 	for {
 		select {
 		case <-tc.C:
-			<-w.Exec(t.tick)
+			<-w.exec(t.tick)
 		case <-w.closing:
 			// World is being closed: Stop ticking and get rid of a task.
 			w.running.Done()
@@ -38,12 +38,12 @@ func (t ticker) tickLoop(w *World) {
 // automatically 20 times per second. Synchronous Worlds tick loaded chunks
 // even when no viewers are present.
 func (w *World) AdvanceTick() {
-	<-w.Exec(ticker{}.tick)
+	<-w.exec(ticker{}.tick)
 }
 
 // tick performs a tick on the World and updates the time, weather, blocks and
 // entities that require updates.
-func (t ticker) tick(tx *Tx) {
+func (t ticker) tick(tx *Context) {
 	viewers, loaders := tx.World().allViewers()
 	w := tx.World()
 
@@ -104,7 +104,7 @@ func (t ticker) tick(tx *Tx) {
 }
 
 // performNeighbourUpdates performs all block updates that came as a result of a neighbouring block being changed.
-func (t ticker) performNeighbourUpdates(tx *Tx) {
+func (t ticker) performNeighbourUpdates(tx *Context) {
 	updates := slices.Clone(tx.World().neighbourUpdates)
 	clear(tx.World().neighbourUpdates)
 	tx.World().neighbourUpdates = tx.World().neighbourUpdates[:0]
@@ -123,7 +123,7 @@ func (t ticker) performNeighbourUpdates(tx *Tx) {
 }
 
 // tickBlocksRandomly executes random block ticks in loaded chunks within range of loaders.
-func (t ticker) tickBlocksRandomly(tx *Tx, loaders []*Loader, tick int64) {
+func (t ticker) tickBlocksRandomly(tx *Context, loaders []*Loader, tick int64) {
 	var (
 		r             = int32(tx.World().tickRange())
 		g             randUint4
@@ -208,7 +208,7 @@ func (t ticker) anyWithinDistance(pos ChunkPos, loaded []ChunkPos, r int32) bool
 
 // tickEntities ticks all entities in the world, making sure they are still located in the correct chunks and
 // updating where necessary.
-func (t ticker) tickEntities(tx *Tx, tick int64) {
+func (t ticker) tickEntities(tx *Context, tick int64) {
 	for handle, lastPos := range tx.World().entities {
 		e := handle.mustEntity(tx)
 		chunkPos := chunkPosFromVec3(handle.data.Pos)
@@ -305,7 +305,7 @@ func newScheduledTickQueue(tick int64) *scheduledTickQueue {
 // tick processes scheduled ticks, calling ScheduledTicker.ScheduledTick for any
 // block update that is scheduled for the tick passed, and removing it from the
 // queue.
-func (queue *scheduledTickQueue) tick(tx *Tx, tick int64) {
+func (queue *scheduledTickQueue) tick(tx *Context, tick int64) {
 	queue.currentTick = tick
 
 	w := tx.World()

--- a/server/world/tx.go
+++ b/server/world/tx.go
@@ -11,47 +11,30 @@ import (
 	"github.com/go-gl/mathgl/mgl64"
 )
 
-// Tx is a transitional alias for Context that keeps existing *world.Tx
-// signatures compiling. New code should use Context; a follow-up removes it.
-type Tx = Context
-
-// Context is the owner-scoped handle passed to world callbacks; it is the only
-// way to perform world operations and is valid only during its callback.
-// Off-owner code obtains one via World.Do, world.Call, EntityRef.Do, or player.Ref.
-type Context struct {
-	*tx
-
-	// cancel records whether an event Context was cancelled by a handler.
-	cancel bool
-}
-
-// tx is the unexported transaction state shared by every Context derived from
-// it (via Event) within one owner callback.
-type tx struct {
+// Tx is the owner transaction handle passed to world callbacks. It is the
+// only way to perform world operations and is valid only during its callback.
+type Tx struct {
 	w        *World
 	closed   bool
 	deferred []scheduledTransaction
 }
 
-// contextAlloc bundles a Context with its transaction so newContext costs one
-// allocation on the per-transaction hot path.
-type contextAlloc struct {
-	ctx Context
-	tx  tx
+// Context is a cancellable event scope passed to Handler events. It embeds the
+// owner transaction, so world operations are available directly on it.
+type Context struct {
+	*Tx
+	cancel bool
 }
 
-// newContext returns a Context backed by a fresh transaction on World w.
-func newContext(w *World) *Context {
-	a := &contextAlloc{tx: tx{w: w}}
-	a.ctx.tx = &a.tx
-	return &a.ctx
+// newTx returns a fresh transaction on World w.
+func newTx(w *World) *Tx {
+	return &Tx{w: w}
 }
 
-// Event returns a Context sharing ctx's transaction but with its own cancel
-// state, so dispatching one Handler event can't cancel another in the same
-// transaction. Only code that fires world/player Handler events needs it.
-func (ctx *Context) Event() *Context {
-	return &Context{tx: ctx.tx}
+// Event returns a fresh Context for dispatching one Handler event on this
+// transaction, so cancelling one event cannot affect another.
+func (tx *Tx) Event() *Context {
+	return &Context{Tx: tx}
 }
 
 // Cancelled returns whether the Context has been cancelled by an event handler.
@@ -61,24 +44,26 @@ func (ctx *Context) Cancelled() bool { return ctx.cancel }
 // default behaviour of the event should not run.
 func (ctx *Context) Cancel() { ctx.cancel = true }
 
-// Defer schedules f to run on the owner after the current callback completes.
-func (ctx *Context) Defer(f func(ctx *Context)) *Task {
-	return ctx.DeferErr(func(ctx *Context) error {
-		f(ctx)
+// Defer schedules f to run on the owner after the current callback completes
+// and before the parent Task completes. Deferred callbacks run FIFO in
+// registration order, unlike Go defer's LIFO order.
+func (tx *Tx) Defer(f func(tx *Tx)) *Task {
+	return tx.DeferErr(func(tx *Tx) error {
+		f(tx)
 		return nil
 	})
 }
 
 // DeferErr schedules f to run on the owner after the current callback
 // completes, recording any returned error on the Task.
-func (ctx *Context) DeferErr(f func(ctx *Context) error) *Task {
-	return ctx.deferTask(f)
+func (tx *Tx) DeferErr(f func(tx *Tx) error) *Task {
+	return tx.deferTask(f)
 }
 
-// Range returns the lower and upper bounds of the World that the Context is
+// Range returns the lower and upper bounds of the World that the Tx is
 // operating on.
-func (ctx *Context) Range() cube.Range {
-	return ctx.World().ra
+func (tx *Tx) Range() cube.Range {
+	return tx.World().ra
 }
 
 // SetBlock writes a block to the position passed. If a chunk is not yet loaded
@@ -95,22 +80,22 @@ func (ctx *Context) Range() cube.Range {
 // SetBlock should be avoided in situations where performance is critical when
 // needing to set a lot of blocks to the world. BuildStructure may be used
 // instead.
-func (ctx *Context) SetBlock(pos cube.Pos, b Block, opts *SetOpts) {
-	ctx.World().setBlock(pos, b, opts)
+func (tx *Tx) SetBlock(pos cube.Pos, b Block, opts *SetOpts) {
+	tx.World().setBlock(pos, b, opts)
 }
 
 // Block reads a block from the position passed. If a chunk is not yet loaded
 // at that position, the chunk is loaded, or generated if it could not be found
 // in the world save, and the block returned.
-func (ctx *Context) Block(pos cube.Pos) Block {
-	return ctx.World().block(pos)
+func (tx *Tx) Block(pos cube.Pos) Block {
+	return tx.World().block(pos)
 }
 
 // Liquid attempts to return a Liquid block at the position passed. This
 // Liquid may be in the foreground or in any other layer. If found, the Liquid
 // is returned. If not, the bool returned is false.
-func (ctx *Context) Liquid(pos cube.Pos) (Liquid, bool) {
-	return ctx.World().liquid(pos)
+func (tx *Tx) Liquid(pos cube.Pos) (Liquid, bool) {
+	return tx.World().liquid(pos)
 }
 
 // SetLiquid sets a Liquid at a specific position in the World. Unlike
@@ -119,8 +104,8 @@ func (ctx *Context) Liquid(pos cube.Pos) (Liquid, bool) {
 // there already is a Liquid at that position, in which case it will be
 // overwritten. If nil is passed for the Liquid, any Liquid currently present
 // will be removed.
-func (ctx *Context) SetLiquid(pos cube.Pos, b Liquid) {
-	ctx.World().setLiquid(pos, b)
+func (tx *Tx) SetLiquid(pos cube.Pos, b Liquid) {
+	tx.World().setLiquid(pos, b)
 }
 
 // BuildStructure builds a Structure passed at a specific position in the
@@ -130,8 +115,8 @@ func (ctx *Context) SetLiquid(pos cube.Pos, b Liquid) {
 // will do so within much less time than separate SetBlock calls would. The
 // method operates on a per-chunk basis, setting all blocks within a single
 // chunk part of the Structure before moving on to the next chunk.
-func (ctx *Context) BuildStructure(pos cube.Pos, s Structure) {
-	ctx.World().buildStructure(pos, s)
+func (tx *Tx) BuildStructure(pos cube.Pos, s Structure) {
+	tx.World().buildStructure(pos, s)
 }
 
 // ScheduleBlockUpdate schedules a block update at the position passed for the
@@ -140,109 +125,109 @@ func (ctx *Context) BuildStructure(pos cube.Pos, s Structure) {
 // Block updates are both block and position specific. A block update is only
 // scheduled if no block update with the same position and block type is
 // already scheduled at a later time than the newly scheduled update.
-func (ctx *Context) ScheduleBlockUpdate(pos cube.Pos, b Block, delay time.Duration) {
-	ctx.World().scheduleBlockUpdate(pos, b, delay)
+func (tx *Tx) ScheduleBlockUpdate(pos cube.Pos, b Block, delay time.Duration) {
+	tx.World().scheduleBlockUpdate(pos, b, delay)
 }
 
 // HighestLightBlocker gets the Y value of the highest fully light blocking
 // block at the x and z values passed in the World.
-func (ctx *Context) HighestLightBlocker(x, z int) int {
-	return ctx.World().HighestLightBlocker(x, z)
+func (tx *Tx) HighestLightBlocker(x, z int) int {
+	return tx.World().HighestLightBlocker(x, z)
 }
 
 // HighestBlock looks up the highest non-air block in the World at a specific x
 // and z. The y value of the highest block is returned, or 0 if no blocks were
 // present in the column.
-func (ctx *Context) HighestBlock(x, z int) int {
-	return ctx.World().highestBlock(x, z)
+func (tx *Tx) HighestBlock(x, z int) int {
+	return tx.World().highestBlock(x, z)
 }
 
 // Light returns the light level at the position passed. This is the highest of
 // the sky- and block light. The light value returned is a value in the range
 // 0-15, where 0 means there is no light present, whereas 15 means the block is
 // fully lit.
-func (ctx *Context) Light(pos cube.Pos) uint8 {
-	return ctx.World().light(pos)
+func (tx *Tx) Light(pos cube.Pos) uint8 {
+	return tx.World().light(pos)
 }
 
 // SkyLight returns the skylight level at the position passed. This light level
 // is not influenced by blocks that emit light, such as torches. The light
 // value, similarly to Light, is a value in the range 0-15, where 0 means no
 // light is present.
-func (ctx *Context) SkyLight(pos cube.Pos) uint8 {
-	return ctx.World().skyLight(pos)
+func (tx *Tx) SkyLight(pos cube.Pos) uint8 {
+	return tx.World().skyLight(pos)
 }
 
 // SetBiome sets the Biome at the position passed. If a chunk is not yet loaded
 // at that position, the chunk is first loaded or generated if it could not be
 // found in the world save.
-func (ctx *Context) SetBiome(pos cube.Pos, b Biome) {
-	ctx.World().setBiome(pos, b)
+func (tx *Tx) SetBiome(pos cube.Pos, b Biome) {
+	tx.World().setBiome(pos, b)
 }
 
 // Biome reads the Biome at the position passed. If a chunk is not yet loaded
 // at that position, the chunk is loaded, or generated if it could not be found
 // in the world save, and the Biome returned.
-func (ctx *Context) Biome(pos cube.Pos) Biome {
-	return ctx.World().biome(pos)
+func (tx *Tx) Biome(pos cube.Pos) Biome {
+	return tx.World().biome(pos)
 }
 
 // Temperature returns the temperature in the World at a specific position.
 // Higher altitudes and different biomes influence the temperature returned.
-func (ctx *Context) Temperature(pos cube.Pos) float64 {
-	return ctx.World().temperature(pos)
+func (tx *Tx) Temperature(pos cube.Pos) float64 {
+	return tx.World().temperature(pos)
 }
 
 // RainingAt checks if it is raining at a specific cube.Pos in the World. True
 // is returned if it is raining, if the temperature is high enough in the biome
 // for it not to be snow and if the block is above the top-most obstructing
 // block.
-func (ctx *Context) RainingAt(pos cube.Pos) bool {
-	return ctx.World().rainingAt(pos)
+func (tx *Tx) RainingAt(pos cube.Pos) bool {
+	return tx.World().rainingAt(pos)
 }
 
 // SnowingAt checks if it is snowing at a specific cube.Pos in the World. True
 // is returned if the temperature in the Biome at that position is sufficiently
 // low, if it is raining and if it's above the top-most obstructing block.
-func (ctx *Context) SnowingAt(pos cube.Pos) bool {
-	return ctx.World().snowingAt(pos)
+func (tx *Tx) SnowingAt(pos cube.Pos) bool {
+	return tx.World().snowingAt(pos)
 }
 
 // ThunderingAt checks if it is thundering at a specific cube.Pos in the World.
 // True is returned if RainingAt returns true and if it is thundering in the
 // world.
-func (ctx *Context) ThunderingAt(pos cube.Pos) bool {
-	return ctx.World().thunderingAt(pos)
+func (tx *Tx) ThunderingAt(pos cube.Pos) bool {
+	return tx.World().thunderingAt(pos)
 }
 
 // Raining checks if it is raining anywhere in the World.
-func (ctx *Context) Raining() bool {
-	return ctx.World().raining()
+func (tx *Tx) Raining() bool {
+	return tx.World().raining()
 }
 
 // Thundering checks if it is thundering anywhere in the World.
-func (ctx *Context) Thundering() bool {
-	return ctx.World().thundering()
+func (tx *Tx) Thundering() bool {
+	return tx.World().thundering()
 }
 
 // AddParticle spawns a Particle at a given position in the World. Viewers that
 // are viewing the chunk will be shown the particle.
-func (ctx *Context) AddParticle(pos mgl64.Vec3, p Particle) {
-	ctx.World().addParticle(pos, p)
+func (tx *Tx) AddParticle(pos mgl64.Vec3, p Particle) {
+	tx.World().addParticle(pos, p)
 }
 
 // PlayEntityAnimation plays an animation on an entity in the World. The animation is played for all viewers
 // of the entity.
-func (ctx *Context) PlayEntityAnimation(e Entity, a EntityAnimation) {
-	for _, viewer := range ctx.World().viewersOf(e.Position()) {
+func (tx *Tx) PlayEntityAnimation(e Entity, a EntityAnimation) {
+	for _, viewer := range tx.World().viewersOf(e.Position()) {
 		viewer.ViewEntityAnimation(e, a)
 	}
 }
 
 // PlaySound plays a sound at a specific position in the World. Viewers of that
 // position will be able to hear the sound if they are close enough.
-func (ctx *Context) PlaySound(pos mgl64.Vec3, s Sound) {
-	ctx.World().playSound(ctx, pos, s)
+func (tx *Tx) PlaySound(pos mgl64.Vec3, s Sound) {
+	tx.World().playSound(tx, pos, s)
 }
 
 // AddEntity adds an EntityHandle to a World. The Entity will be visible to all
@@ -250,42 +235,42 @@ func (ctx *Context) PlaySound(pos mgl64.Vec3, s Sound) {
 // the chunk that the EntityHandle is in is not yet loaded, it will first be
 // loaded. AddEntity panics if the EntityHandle is already in a world.
 // AddEntity returns the Entity created by the EntityHandle.
-func (ctx *Context) AddEntity(e *EntityHandle) Entity {
-	return ctx.World().addEntity(ctx, e)
+func (tx *Tx) AddEntity(e *EntityHandle) Entity {
+	return tx.World().addEntity(tx, e)
 }
 
 // RemoveEntity removes an Entity from the World that is currently present in
 // it. Any viewers of the Entity will no longer be able to see it.
 // RemoveEntity returns the EntityHandle of the Entity. After removing an Entity
 // from the World, the Entity is no longer usable.
-func (ctx *Context) RemoveEntity(e Entity) *EntityHandle {
-	return ctx.World().removeEntity(e, ctx)
+func (tx *Tx) RemoveEntity(e Entity) *EntityHandle {
+	return tx.World().removeEntity(e, tx)
 }
 
 // EntitiesWithin returns an iterator that yields all entities contained within
 // the cube.BBox passed.
-func (ctx *Context) EntitiesWithin(box cube.BBox) iter.Seq[Entity] {
-	return ctx.World().entitiesWithin(ctx, box)
+func (tx *Tx) EntitiesWithin(box cube.BBox) iter.Seq[Entity] {
+	return tx.World().entitiesWithin(tx, box)
 }
 
 // Entities returns an iterator that yields all entities in the World.
-func (ctx *Context) Entities() iter.Seq[Entity] {
-	return ctx.World().allEntities(ctx)
+func (tx *Tx) Entities() iter.Seq[Entity] {
+	return tx.World().allEntities(tx)
 }
 
 // Players returns an iterator that yields all player entities in the World.
-func (ctx *Context) Players() iter.Seq[Entity] {
-	return ctx.World().allPlayers(ctx)
+func (tx *Tx) Players() iter.Seq[Entity] {
+	return tx.World().allPlayers(tx)
 }
 
 // Viewers returns all viewers viewing the position passed.
-func (ctx *Context) Viewers(pos mgl64.Vec3) []Viewer {
-	return ctx.World().viewersOf(pos)
+func (tx *Tx) Viewers(pos mgl64.Vec3) []Viewer {
+	return tx.World().viewersOf(pos)
 }
 
 // Sleepers returns an iterator that yields all sleeping entities currently added to the World.
-func (ctx *Context) Sleepers() iter.Seq[Sleeper] {
-	ent := ctx.Entities()
+func (tx *Tx) Sleepers() iter.Seq[Sleeper] {
+	ent := tx.Entities()
 	return func(yield func(Sleeper) bool) {
 		for e := range ent {
 			if sleeper, ok := e.(Sleeper); ok {
@@ -298,8 +283,8 @@ func (ctx *Context) Sleepers() iter.Seq[Sleeper] {
 }
 
 // BroadcastSleepingIndicator broadcasts a sleeping indicator to all sleepers in the world.
-func (ctx *Context) BroadcastSleepingIndicator() {
-	sleepers := ctx.Sleepers()
+func (tx *Tx) BroadcastSleepingIndicator() {
+	sleepers := tx.Sleepers()
 
 	var sleeping, allSleepers int
 	for s := range sleepers {
@@ -316,8 +301,8 @@ func (ctx *Context) BroadcastSleepingIndicator() {
 
 // BroadcastSleepingReminder broadcasts a sleeping reminder message to all sleepers in the world, excluding the sleeper
 // passed.
-func (ctx *Context) BroadcastSleepingReminder(sleeper Sleeper) {
-	sleepers := ctx.Sleepers()
+func (tx *Tx) BroadcastSleepingReminder(sleeper Sleeper) {
+	sleepers := tx.Sleepers()
 
 	var notSleeping int
 	for s := range sleepers {
@@ -335,10 +320,10 @@ func (ctx *Context) BroadcastSleepingReminder(sleeper Sleeper) {
 
 // RedstonePower returns the redstone power emitted by the block at pos toward a neighbouring receiver.
 // The face argument is relative to the receiving block.
-func (ctx *Context) RedstonePower(pos cube.Pos, face cube.Face, accountForDust bool) (power int) {
-	b := ctx.Block(pos)
+func (tx *Tx) RedstonePower(pos cube.Pos, face cube.Face, accountForDust bool) (power int) {
+	b := tx.Block(pos)
 	if c, ok := b.(Conductor); ok {
-		return c.WeakPower(pos, face, ctx, accountForDust)
+		return c.WeakPower(pos, face, tx, accountForDust)
 	}
 	// The wiki states that in the future some blocks may be transparent but still relay redstone.
 	// If a block implements RedstonePowerRelayer, it should always be prioritised over lightDiffuser.
@@ -350,72 +335,71 @@ func (ctx *Context) RedstonePower(pos cube.Pos, face cube.Face, accountForDust b
 		return 0
 	}
 	for _, f := range cube.Faces() {
-		if !b.Model().FaceSolid(pos, f, ctx) {
+		if !b.Model().FaceSolid(pos, f, tx) {
 			return 0
 		}
 	}
 	for _, f := range cube.Faces() {
-		c, ok := ctx.Block(pos.Side(f)).(Conductor)
+		c, ok := tx.Block(pos.Side(f)).(Conductor)
 		if !ok {
 			continue
 		}
 		sourcePos := pos.Side(f)
-		power = max(power, c.StrongPower(sourcePos, f, ctx, accountForDust))
+		power = max(power, c.StrongPower(sourcePos, f, tx, accountForDust))
 		if !accountForDust {
 			continue
 		}
 		if weakBlockPowerer, ok := c.(WeakBlockPowerer); ok && weakBlockPowerer.WeaklyPowersBlocks() {
-			power = max(power, c.WeakPower(sourcePos, f, ctx, accountForDust))
+			power = max(power, c.WeakPower(sourcePos, f, tx, accountForDust))
 		}
 	}
 	return power
 }
 
-func (ctx *Context) deferTask(f func(ctx *Context) error) *Task {
-	task := newTask()
-	if ctx.closed {
-		task.failIfPending(ErrWorldClosed)
-		return task
+func (tx *Tx) deferTask(f func(tx *Tx) error) *Task {
+	if tx.closed {
+		panic("world.Tx: use of transaction after transaction finishes is not permitted")
 	}
-	ctx.deferred = append(ctx.deferred, scheduledTransaction{task: task, f: f})
+	task := newTask()
+	tx.deferred = append(tx.deferred, scheduledTransaction{task: task, f: f})
 	return task
 }
 
-// World returns the Context's World. It panics once the callback has
+// World returns the Tx's World. It panics once the callback has
 // completed. Treat the result as the off-owner handle: blocking calls like
 // Save and Close deadlock from inside the callback, so do world operations
-// through the Context instead.
-func (ctx *Context) World() *World {
-	if ctx.closed {
-		panic("world.Context: use of transaction after transaction finishes is not permitted")
+// through the Tx instead.
+func (tx *Tx) World() *World {
+	if tx.closed {
+		panic("world.Tx: use of transaction after transaction finishes is not permitted")
 	}
-	return ctx.w
+	return tx.w
 }
 
 // CurrentTick returns the current tick of the transaction's world.
-func (ctx *Context) CurrentTick() int64 {
-	w := ctx.World()
+func (tx *Tx) CurrentTick() int64 {
+	w := tx.World()
 	w.set.Lock()
 	defer w.set.Unlock()
 	return w.set.CurrentTick
 }
 
 // Redstone returns the transient redstone runtime state owned by the transaction's world.
-func (ctx *Context) Redstone() *redstone.State {
-	return &ctx.World().redstone
+func (tx *Tx) Redstone() *redstone.State {
+	return &tx.World().redstone
 }
 
-// close finishes the Context, causing any following call on the Context to panic.
-func (ctx *Context) close() {
-	ctx.closed = true
+// close finishes the Tx, causing any following call on the Tx to panic.
+func (tx *Tx) close() {
+	tx.closed = true
 }
 
-func (ctx *Context) runDeferred() {
-	for len(ctx.deferred) > 0 {
-		deferred := ctx.deferred
-		ctx.deferred = nil
+func (tx *Tx) runDeferred() {
+	for len(tx.deferred) > 0 {
+		deferred := tx.deferred
+		tx.deferred = nil
 		for _, st := range deferred {
-			st.Run(ctx.w)
+			st.Run(tx.w)
 		}
 	}
 }
@@ -424,16 +408,16 @@ func (ctx *Context) runDeferred() {
 // using World.exec().
 type normalTransaction struct {
 	c chan struct{}
-	f func(ctx *Context)
+	f func(tx *Tx)
 }
 
-// Run creates a *Context, calls ntx.f, closes the transaction and finally closes
+// Run creates a *Tx, calls ntx.f, closes the transaction and finally closes
 // ntx.c.
 func (ntx normalTransaction) Run(w *World) {
-	ctx := newContext(w)
-	ntx.f(ctx)
-	ctx.close()
-	ctx.runDeferred()
+	tx := newTx(w)
+	ntx.f(tx)
+	tx.close()
+	tx.runDeferred()
 	close(ntx.c)
 }
 
@@ -441,21 +425,21 @@ func (ntx normalTransaction) Run(w *World) {
 // predicate before the transaction is run.
 type weakTransaction struct {
 	c     chan bool
-	f     func(ctx *Context)
+	f     func(tx *Tx)
 	valid func() bool
 	cond  *sync.Cond
 }
 
 // Run runs the transaction, first checking if it is still valid and creating a
-// *Context if so. Afterwards, a bool indicating if the transaction was run is added
+// *Tx if so. Afterwards, a bool indicating if the transaction was run is added
 // to wtx.c. Finally, wtx.cond.Broadcast() is called.
 func (wtx weakTransaction) Run(w *World) {
 	valid := wtx.valid == nil || wtx.valid()
 	if valid {
-		ctx := newContext(w)
-		wtx.f(ctx)
-		ctx.close()
-		ctx.runDeferred()
+		tx := newTx(w)
+		wtx.f(tx)
+		tx.close()
+		tx.runDeferred()
 	}
 	// We have to acquire a lock on wtx.cond.L here to make sure cond.Wait()
 	// has been called before we call cond.Broadcast(). If not, we might

--- a/server/world/tx.go
+++ b/server/world/tx.go
@@ -3,7 +3,6 @@ package world
 import (
 	"iter"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
@@ -12,18 +11,74 @@ import (
 	"github.com/go-gl/mathgl/mgl64"
 )
 
-// Tx represents a synchronised transaction performed on a World. Most
-// operations on a World can only be called through a transaction. Tx is not
-// safe for use by multiple goroutines concurrently.
-type Tx struct {
-	w      *World
-	closed bool
+// Tx is a transitional alias for Context that keeps existing *world.Tx
+// signatures compiling. New code should use Context; a follow-up removes it.
+type Tx = Context
+
+// Context is the owner-scoped handle passed to world callbacks; it is the only
+// way to perform world operations and is valid only during its callback.
+// Off-owner code obtains one via World.Do, world.Call, EntityRef.Do, or player.Ref.
+type Context struct {
+	*tx
+
+	// cancel records whether an event Context was cancelled by a handler.
+	cancel bool
 }
 
-// Range returns the lower and upper bounds of the World that the Tx is
+// tx is the unexported transaction state shared by every Context derived from
+// it (via Event) within one owner callback.
+type tx struct {
+	w        *World
+	closed   bool
+	deferred []scheduledTransaction
+}
+
+// contextAlloc bundles a Context with its transaction so newContext costs one
+// allocation on the per-transaction hot path.
+type contextAlloc struct {
+	ctx Context
+	tx  tx
+}
+
+// newContext returns a Context backed by a fresh transaction on World w.
+func newContext(w *World) *Context {
+	a := &contextAlloc{tx: tx{w: w}}
+	a.ctx.tx = &a.tx
+	return &a.ctx
+}
+
+// Event returns a Context sharing ctx's transaction but with its own cancel
+// state, so dispatching one Handler event can't cancel another in the same
+// transaction. Only code that fires world/player Handler events needs it.
+func (ctx *Context) Event() *Context {
+	return &Context{tx: ctx.tx}
+}
+
+// Cancelled returns whether the Context has been cancelled by an event handler.
+func (ctx *Context) Cancelled() bool { return ctx.cancel }
+
+// Cancel cancels the Context. It is used by event handlers to signal that the
+// default behaviour of the event should not run.
+func (ctx *Context) Cancel() { ctx.cancel = true }
+
+// Defer schedules f to run on the owner after the current callback completes.
+func (ctx *Context) Defer(f func(ctx *Context)) *Task {
+	return ctx.DeferErr(func(ctx *Context) error {
+		f(ctx)
+		return nil
+	})
+}
+
+// DeferErr schedules f to run on the owner after the current callback
+// completes, recording any returned error on the Task.
+func (ctx *Context) DeferErr(f func(ctx *Context) error) *Task {
+	return ctx.deferTask(f)
+}
+
+// Range returns the lower and upper bounds of the World that the Context is
 // operating on.
-func (tx *Tx) Range() cube.Range {
-	return tx.w.ra
+func (ctx *Context) Range() cube.Range {
+	return ctx.World().ra
 }
 
 // SetBlock writes a block to the position passed. If a chunk is not yet loaded
@@ -40,22 +95,22 @@ func (tx *Tx) Range() cube.Range {
 // SetBlock should be avoided in situations where performance is critical when
 // needing to set a lot of blocks to the world. BuildStructure may be used
 // instead.
-func (tx *Tx) SetBlock(pos cube.Pos, b Block, opts *SetOpts) {
-	tx.World().setBlock(pos, b, opts)
+func (ctx *Context) SetBlock(pos cube.Pos, b Block, opts *SetOpts) {
+	ctx.World().setBlock(pos, b, opts)
 }
 
 // Block reads a block from the position passed. If a chunk is not yet loaded
 // at that position, the chunk is loaded, or generated if it could not be found
 // in the world save, and the block returned.
-func (tx *Tx) Block(pos cube.Pos) Block {
-	return tx.World().block(pos)
+func (ctx *Context) Block(pos cube.Pos) Block {
+	return ctx.World().block(pos)
 }
 
 // Liquid attempts to return a Liquid block at the position passed. This
 // Liquid may be in the foreground or in any other layer. If found, the Liquid
 // is returned. If not, the bool returned is false.
-func (tx *Tx) Liquid(pos cube.Pos) (Liquid, bool) {
-	return tx.World().liquid(pos)
+func (ctx *Context) Liquid(pos cube.Pos) (Liquid, bool) {
+	return ctx.World().liquid(pos)
 }
 
 // SetLiquid sets a Liquid at a specific position in the World. Unlike
@@ -64,8 +119,8 @@ func (tx *Tx) Liquid(pos cube.Pos) (Liquid, bool) {
 // there already is a Liquid at that position, in which case it will be
 // overwritten. If nil is passed for the Liquid, any Liquid currently present
 // will be removed.
-func (tx *Tx) SetLiquid(pos cube.Pos, b Liquid) {
-	tx.World().setLiquid(pos, b)
+func (ctx *Context) SetLiquid(pos cube.Pos, b Liquid) {
+	ctx.World().setLiquid(pos, b)
 }
 
 // BuildStructure builds a Structure passed at a specific position in the
@@ -75,8 +130,8 @@ func (tx *Tx) SetLiquid(pos cube.Pos, b Liquid) {
 // will do so within much less time than separate SetBlock calls would. The
 // method operates on a per-chunk basis, setting all blocks within a single
 // chunk part of the Structure before moving on to the next chunk.
-func (tx *Tx) BuildStructure(pos cube.Pos, s Structure) {
-	tx.World().buildStructure(pos, s)
+func (ctx *Context) BuildStructure(pos cube.Pos, s Structure) {
+	ctx.World().buildStructure(pos, s)
 }
 
 // ScheduleBlockUpdate schedules a block update at the position passed for the
@@ -85,109 +140,109 @@ func (tx *Tx) BuildStructure(pos cube.Pos, s Structure) {
 // Block updates are both block and position specific. A block update is only
 // scheduled if no block update with the same position and block type is
 // already scheduled at a later time than the newly scheduled update.
-func (tx *Tx) ScheduleBlockUpdate(pos cube.Pos, b Block, delay time.Duration) {
-	tx.World().scheduleBlockUpdate(pos, b, delay)
+func (ctx *Context) ScheduleBlockUpdate(pos cube.Pos, b Block, delay time.Duration) {
+	ctx.World().scheduleBlockUpdate(pos, b, delay)
 }
 
 // HighestLightBlocker gets the Y value of the highest fully light blocking
 // block at the x and z values passed in the World.
-func (tx *Tx) HighestLightBlocker(x, z int) int {
-	return tx.World().HighestLightBlocker(x, z)
+func (ctx *Context) HighestLightBlocker(x, z int) int {
+	return ctx.World().HighestLightBlocker(x, z)
 }
 
 // HighestBlock looks up the highest non-air block in the World at a specific x
 // and z. The y value of the highest block is returned, or 0 if no blocks were
 // present in the column.
-func (tx *Tx) HighestBlock(x, z int) int {
-	return tx.World().highestBlock(x, z)
+func (ctx *Context) HighestBlock(x, z int) int {
+	return ctx.World().highestBlock(x, z)
 }
 
 // Light returns the light level at the position passed. This is the highest of
 // the sky- and block light. The light value returned is a value in the range
 // 0-15, where 0 means there is no light present, whereas 15 means the block is
 // fully lit.
-func (tx *Tx) Light(pos cube.Pos) uint8 {
-	return tx.World().light(pos)
+func (ctx *Context) Light(pos cube.Pos) uint8 {
+	return ctx.World().light(pos)
 }
 
 // SkyLight returns the skylight level at the position passed. This light level
 // is not influenced by blocks that emit light, such as torches. The light
 // value, similarly to Light, is a value in the range 0-15, where 0 means no
 // light is present.
-func (tx *Tx) SkyLight(pos cube.Pos) uint8 {
-	return tx.World().skyLight(pos)
+func (ctx *Context) SkyLight(pos cube.Pos) uint8 {
+	return ctx.World().skyLight(pos)
 }
 
 // SetBiome sets the Biome at the position passed. If a chunk is not yet loaded
 // at that position, the chunk is first loaded or generated if it could not be
 // found in the world save.
-func (tx *Tx) SetBiome(pos cube.Pos, b Biome) {
-	tx.World().setBiome(pos, b)
+func (ctx *Context) SetBiome(pos cube.Pos, b Biome) {
+	ctx.World().setBiome(pos, b)
 }
 
 // Biome reads the Biome at the position passed. If a chunk is not yet loaded
 // at that position, the chunk is loaded, or generated if it could not be found
 // in the world save, and the Biome returned.
-func (tx *Tx) Biome(pos cube.Pos) Biome {
-	return tx.World().biome(pos)
+func (ctx *Context) Biome(pos cube.Pos) Biome {
+	return ctx.World().biome(pos)
 }
 
 // Temperature returns the temperature in the World at a specific position.
 // Higher altitudes and different biomes influence the temperature returned.
-func (tx *Tx) Temperature(pos cube.Pos) float64 {
-	return tx.World().temperature(pos)
+func (ctx *Context) Temperature(pos cube.Pos) float64 {
+	return ctx.World().temperature(pos)
 }
 
 // RainingAt checks if it is raining at a specific cube.Pos in the World. True
 // is returned if it is raining, if the temperature is high enough in the biome
 // for it not to be snow and if the block is above the top-most obstructing
 // block.
-func (tx *Tx) RainingAt(pos cube.Pos) bool {
-	return tx.World().rainingAt(pos)
+func (ctx *Context) RainingAt(pos cube.Pos) bool {
+	return ctx.World().rainingAt(pos)
 }
 
 // SnowingAt checks if it is snowing at a specific cube.Pos in the World. True
 // is returned if the temperature in the Biome at that position is sufficiently
 // low, if it is raining and if it's above the top-most obstructing block.
-func (tx *Tx) SnowingAt(pos cube.Pos) bool {
-	return tx.World().snowingAt(pos)
+func (ctx *Context) SnowingAt(pos cube.Pos) bool {
+	return ctx.World().snowingAt(pos)
 }
 
 // ThunderingAt checks if it is thundering at a specific cube.Pos in the World.
 // True is returned if RainingAt returns true and if it is thundering in the
 // world.
-func (tx *Tx) ThunderingAt(pos cube.Pos) bool {
-	return tx.World().thunderingAt(pos)
+func (ctx *Context) ThunderingAt(pos cube.Pos) bool {
+	return ctx.World().thunderingAt(pos)
 }
 
 // Raining checks if it is raining anywhere in the World.
-func (tx *Tx) Raining() bool {
-	return tx.World().raining()
+func (ctx *Context) Raining() bool {
+	return ctx.World().raining()
 }
 
 // Thundering checks if it is thundering anywhere in the World.
-func (tx *Tx) Thundering() bool {
-	return tx.World().thundering()
+func (ctx *Context) Thundering() bool {
+	return ctx.World().thundering()
 }
 
 // AddParticle spawns a Particle at a given position in the World. Viewers that
 // are viewing the chunk will be shown the particle.
-func (tx *Tx) AddParticle(pos mgl64.Vec3, p Particle) {
-	tx.World().addParticle(pos, p)
+func (ctx *Context) AddParticle(pos mgl64.Vec3, p Particle) {
+	ctx.World().addParticle(pos, p)
 }
 
 // PlayEntityAnimation plays an animation on an entity in the World. The animation is played for all viewers
 // of the entity.
-func (tx *Tx) PlayEntityAnimation(e Entity, a EntityAnimation) {
-	for _, viewer := range tx.World().viewersOf(e.Position()) {
+func (ctx *Context) PlayEntityAnimation(e Entity, a EntityAnimation) {
+	for _, viewer := range ctx.World().viewersOf(e.Position()) {
 		viewer.ViewEntityAnimation(e, a)
 	}
 }
 
 // PlaySound plays a sound at a specific position in the World. Viewers of that
 // position will be able to hear the sound if they are close enough.
-func (tx *Tx) PlaySound(pos mgl64.Vec3, s Sound) {
-	tx.World().playSound(tx, pos, s)
+func (ctx *Context) PlaySound(pos mgl64.Vec3, s Sound) {
+	ctx.World().playSound(ctx, pos, s)
 }
 
 // AddEntity adds an EntityHandle to a World. The Entity will be visible to all
@@ -195,42 +250,42 @@ func (tx *Tx) PlaySound(pos mgl64.Vec3, s Sound) {
 // the chunk that the EntityHandle is in is not yet loaded, it will first be
 // loaded. AddEntity panics if the EntityHandle is already in a world.
 // AddEntity returns the Entity created by the EntityHandle.
-func (tx *Tx) AddEntity(e *EntityHandle) Entity {
-	return tx.World().addEntity(tx, e)
+func (ctx *Context) AddEntity(e *EntityHandle) Entity {
+	return ctx.World().addEntity(ctx, e)
 }
 
 // RemoveEntity removes an Entity from the World that is currently present in
 // it. Any viewers of the Entity will no longer be able to see it.
 // RemoveEntity returns the EntityHandle of the Entity. After removing an Entity
 // from the World, the Entity is no longer usable.
-func (tx *Tx) RemoveEntity(e Entity) *EntityHandle {
-	return tx.World().removeEntity(e, tx)
+func (ctx *Context) RemoveEntity(e Entity) *EntityHandle {
+	return ctx.World().removeEntity(e, ctx)
 }
 
 // EntitiesWithin returns an iterator that yields all entities contained within
 // the cube.BBox passed.
-func (tx *Tx) EntitiesWithin(box cube.BBox) iter.Seq[Entity] {
-	return tx.World().entitiesWithin(tx, box)
+func (ctx *Context) EntitiesWithin(box cube.BBox) iter.Seq[Entity] {
+	return ctx.World().entitiesWithin(ctx, box)
 }
 
 // Entities returns an iterator that yields all entities in the World.
-func (tx *Tx) Entities() iter.Seq[Entity] {
-	return tx.World().allEntities(tx)
+func (ctx *Context) Entities() iter.Seq[Entity] {
+	return ctx.World().allEntities(ctx)
 }
 
 // Players returns an iterator that yields all player entities in the World.
-func (tx *Tx) Players() iter.Seq[Entity] {
-	return tx.World().allPlayers(tx)
+func (ctx *Context) Players() iter.Seq[Entity] {
+	return ctx.World().allPlayers(ctx)
 }
 
 // Viewers returns all viewers viewing the position passed.
-func (tx *Tx) Viewers(pos mgl64.Vec3) []Viewer {
-	return tx.World().viewersOf(pos)
+func (ctx *Context) Viewers(pos mgl64.Vec3) []Viewer {
+	return ctx.World().viewersOf(pos)
 }
 
 // Sleepers returns an iterator that yields all sleeping entities currently added to the World.
-func (tx *Tx) Sleepers() iter.Seq[Sleeper] {
-	ent := tx.Entities()
+func (ctx *Context) Sleepers() iter.Seq[Sleeper] {
+	ent := ctx.Entities()
 	return func(yield func(Sleeper) bool) {
 		for e := range ent {
 			if sleeper, ok := e.(Sleeper); ok {
@@ -243,8 +298,8 @@ func (tx *Tx) Sleepers() iter.Seq[Sleeper] {
 }
 
 // BroadcastSleepingIndicator broadcasts a sleeping indicator to all sleepers in the world.
-func (tx *Tx) BroadcastSleepingIndicator() {
-	sleepers := tx.Sleepers()
+func (ctx *Context) BroadcastSleepingIndicator() {
+	sleepers := ctx.Sleepers()
 
 	var sleeping, allSleepers int
 	for s := range sleepers {
@@ -261,8 +316,8 @@ func (tx *Tx) BroadcastSleepingIndicator() {
 
 // BroadcastSleepingReminder broadcasts a sleeping reminder message to all sleepers in the world, excluding the sleeper
 // passed.
-func (tx *Tx) BroadcastSleepingReminder(sleeper Sleeper) {
-	sleepers := tx.Sleepers()
+func (ctx *Context) BroadcastSleepingReminder(sleeper Sleeper) {
+	sleepers := ctx.Sleepers()
 
 	var notSleeping int
 	for s := range sleepers {
@@ -280,10 +335,10 @@ func (tx *Tx) BroadcastSleepingReminder(sleeper Sleeper) {
 
 // RedstonePower returns the redstone power emitted by the block at pos toward a neighbouring receiver.
 // The face argument is relative to the receiving block.
-func (tx *Tx) RedstonePower(pos cube.Pos, face cube.Face, accountForDust bool) (power int) {
-	b := tx.Block(pos)
+func (ctx *Context) RedstonePower(pos cube.Pos, face cube.Face, accountForDust bool) (power int) {
+	b := ctx.Block(pos)
 	if c, ok := b.(Conductor); ok {
-		return c.WeakPower(pos, face, tx, accountForDust)
+		return c.WeakPower(pos, face, ctx, accountForDust)
 	}
 	// The wiki states that in the future some blocks may be transparent but still relay redstone.
 	// If a block implements RedstonePowerRelayer, it should always be prioritised over lightDiffuser.
@@ -295,88 +350,112 @@ func (tx *Tx) RedstonePower(pos cube.Pos, face cube.Face, accountForDust bool) (
 		return 0
 	}
 	for _, f := range cube.Faces() {
-		if !b.Model().FaceSolid(pos, f, tx) {
+		if !b.Model().FaceSolid(pos, f, ctx) {
 			return 0
 		}
 	}
 	for _, f := range cube.Faces() {
-		c, ok := tx.Block(pos.Side(f)).(Conductor)
+		c, ok := ctx.Block(pos.Side(f)).(Conductor)
 		if !ok {
 			continue
 		}
 		sourcePos := pos.Side(f)
-		power = max(power, c.StrongPower(sourcePos, f, tx, accountForDust))
+		power = max(power, c.StrongPower(sourcePos, f, ctx, accountForDust))
 		if !accountForDust {
 			continue
 		}
 		if weakBlockPowerer, ok := c.(WeakBlockPowerer); ok && weakBlockPowerer.WeaklyPowersBlocks() {
-			power = max(power, c.WeakPower(sourcePos, f, tx, accountForDust))
+			power = max(power, c.WeakPower(sourcePos, f, ctx, accountForDust))
 		}
 	}
 	return power
 }
 
-// World returns the World of the Tx. It panics if the transaction was already
-// marked complete.
-func (tx *Tx) World() *World {
-	if tx.closed {
-		panic("world.Tx: use of transaction after transaction finishes is not permitted")
+func (ctx *Context) deferTask(f func(ctx *Context) error) *Task {
+	task := newTask()
+	if ctx.closed {
+		task.failIfPending(ErrWorldClosed)
+		return task
 	}
-	return tx.w
+	ctx.deferred = append(ctx.deferred, scheduledTransaction{task: task, f: f})
+	return task
+}
+
+// World returns the Context's World. It panics once the callback has
+// completed. Treat the result as the off-owner handle: blocking calls like
+// Save and Close deadlock from inside the callback, so do world operations
+// through the Context instead.
+func (ctx *Context) World() *World {
+	if ctx.closed {
+		panic("world.Context: use of transaction after transaction finishes is not permitted")
+	}
+	return ctx.w
 }
 
 // CurrentTick returns the current tick of the transaction's world.
-func (tx *Tx) CurrentTick() int64 {
-	w := tx.World()
+func (ctx *Context) CurrentTick() int64 {
+	w := ctx.World()
 	w.set.Lock()
 	defer w.set.Unlock()
 	return w.set.CurrentTick
 }
 
 // Redstone returns the transient redstone runtime state owned by the transaction's world.
-func (tx *Tx) Redstone() *redstone.State {
-	return &tx.World().redstone
+func (ctx *Context) Redstone() *redstone.State {
+	return &ctx.World().redstone
 }
 
-// close finishes the Tx, causing any following call on the Tx to panic.
-func (tx *Tx) close() {
-	tx.closed = true
+// close finishes the Context, causing any following call on the Context to panic.
+func (ctx *Context) close() {
+	ctx.closed = true
+}
+
+func (ctx *Context) runDeferred() {
+	for len(ctx.deferred) > 0 {
+		deferred := ctx.deferred
+		ctx.deferred = nil
+		for _, st := range deferred {
+			st.Run(ctx.w)
+		}
+	}
 }
 
 // normalTransaction is added to the transaction queue for transactions created
-// using World.Exec().
+// using World.exec().
 type normalTransaction struct {
 	c chan struct{}
-	f func(tx *Tx)
+	f func(ctx *Context)
 }
 
-// Run creates a *Tx, calls ntx.f, closes the transaction and finally closes
+// Run creates a *Context, calls ntx.f, closes the transaction and finally closes
 // ntx.c.
 func (ntx normalTransaction) Run(w *World) {
-	tx := &Tx{w: w}
-	ntx.f(tx)
-	tx.close()
+	ctx := newContext(w)
+	ntx.f(ctx)
+	ctx.close()
+	ctx.runDeferred()
 	close(ntx.c)
 }
 
-// weakTransaction is a transaction that may be cancelled by setting its invalid
-// bool to false before the transaction is run.
+// weakTransaction is a transaction that may be cancelled by its validity
+// predicate before the transaction is run.
 type weakTransaction struct {
-	c       chan bool
-	f       func(tx *Tx)
-	invalid *atomic.Bool
-	cond    *sync.Cond
+	c     chan bool
+	f     func(ctx *Context)
+	valid func() bool
+	cond  *sync.Cond
 }
 
-// Run runs the transaction, first checking if its invalid bool is false and
-// creating a *Tx if so. Afterwards, a bool indicating if the transaction was
-// run is added to wtx.c. Finally, wtx.cond.Broadcast() is called.
+// Run runs the transaction, first checking if it is still valid and creating a
+// *Context if so. Afterwards, a bool indicating if the transaction was run is added
+// to wtx.c. Finally, wtx.cond.Broadcast() is called.
 func (wtx weakTransaction) Run(w *World) {
-	valid := !wtx.invalid.Load()
+	valid := wtx.valid == nil || wtx.valid()
 	if valid {
-		tx := &Tx{w: w}
-		wtx.f(tx)
-		tx.close()
+		ctx := newContext(w)
+		wtx.f(ctx)
+		ctx.close()
+		ctx.runDeferred()
 	}
 	// We have to acquire a lock on wtx.cond.L here to make sure cond.Wait()
 	// has been called before we call cond.Broadcast(). If not, we might
@@ -385,5 +464,14 @@ func (wtx weakTransaction) Run(w *World) {
 	defer wtx.cond.L.Unlock()
 
 	wtx.c <- valid
+	wtx.cond.Broadcast()
+}
+
+// fail delivers false to a weak transaction that will never run, using the
+// same condition handshake as Run so a waiter in cond.Wait is woken.
+func (wtx weakTransaction) fail() {
+	wtx.cond.L.Lock()
+	defer wtx.cond.L.Unlock()
+	wtx.c <- false
 	wtx.cond.Broadcast()
 }

--- a/server/world/weather.go
+++ b/server/world/weather.go
@@ -187,7 +187,7 @@ func (w weather) enableWeatherCycle(v bool) {
 
 // tickLightning iterates over all loaded chunks in the World, striking
 // lightning in each one with a 1/100,000 chance.
-func (w weather) tickLightning(tx *Context) {
+func (w weather) tickLightning(tx *Tx) {
 	positions := make([]ChunkPos, 0, len(w.w.chunks)/100000)
 	for pos := range w.w.chunks {
 		// Wiki: For each loaded chunk, every tick there is a 1⁄100,000 chance
@@ -206,7 +206,7 @@ func (w weather) tickLightning(tx *Context) {
 // ChunkPos. The final position is influenced by living entities that might be
 // near the lightning strike. If there is no rain at the final position
 // selected, the lightning strike will fail.
-func (w weather) strikeLightning(tx *Context, c ChunkPos) {
+func (w weather) strikeLightning(tx *Tx, c ChunkPos) {
 	if w.w.conf.Entities.conf.Lightning == nil {
 		return
 	}
@@ -218,7 +218,7 @@ func (w weather) strikeLightning(tx *Context, c ChunkPos) {
 // lightningPosition finds a random position in the ChunkPos to strike
 // lightning and adjusts the position to any of the living entities found in or
 // above the position if any are found.
-func (w weather) lightningPosition(tx *Context, c ChunkPos) mgl64.Vec3 {
+func (w weather) lightningPosition(tx *Tx, c ChunkPos) mgl64.Vec3 {
 	v := w.w.r.Int32()
 	x, z := float64(c[0]<<4+(v&0xf)), float64(c[1]<<4+((v>>8)&0xf))
 
@@ -236,7 +236,7 @@ func (w weather) lightningPosition(tx *Context, c ChunkPos) mgl64.Vec3 {
 // any Entity found in the 3x3 column upwards from the mgl64.Vec3. If multiple
 // entities are found, the position of one of the entities is selected
 // randomly.
-func (w weather) adjustPositionToEntities(tx *Context, vec mgl64.Vec3) mgl64.Vec3 {
+func (w weather) adjustPositionToEntities(tx *Tx, vec mgl64.Vec3) mgl64.Vec3 {
 	max := vec.Add(mgl64.Vec3{0, float64(w.w.Range().Max())})
 
 	list := make([]mgl64.Vec3, 0, 16)

--- a/server/world/weather.go
+++ b/server/world/weather.go
@@ -187,7 +187,7 @@ func (w weather) enableWeatherCycle(v bool) {
 
 // tickLightning iterates over all loaded chunks in the World, striking
 // lightning in each one with a 1/100,000 chance.
-func (w weather) tickLightning(tx *Tx) {
+func (w weather) tickLightning(tx *Context) {
 	positions := make([]ChunkPos, 0, len(w.w.chunks)/100000)
 	for pos := range w.w.chunks {
 		// Wiki: For each loaded chunk, every tick there is a 1⁄100,000 chance
@@ -206,7 +206,7 @@ func (w weather) tickLightning(tx *Tx) {
 // ChunkPos. The final position is influenced by living entities that might be
 // near the lightning strike. If there is no rain at the final position
 // selected, the lightning strike will fail.
-func (w weather) strikeLightning(tx *Tx, c ChunkPos) {
+func (w weather) strikeLightning(tx *Context, c ChunkPos) {
 	if w.w.conf.Entities.conf.Lightning == nil {
 		return
 	}
@@ -218,7 +218,7 @@ func (w weather) strikeLightning(tx *Tx, c ChunkPos) {
 // lightningPosition finds a random position in the ChunkPos to strike
 // lightning and adjusts the position to any of the living entities found in or
 // above the position if any are found.
-func (w weather) lightningPosition(tx *Tx, c ChunkPos) mgl64.Vec3 {
+func (w weather) lightningPosition(tx *Context, c ChunkPos) mgl64.Vec3 {
 	v := w.w.r.Int32()
 	x, z := float64(c[0]<<4+(v&0xf)), float64(c[1]<<4+((v>>8)&0xf))
 
@@ -236,7 +236,7 @@ func (w weather) lightningPosition(tx *Tx, c ChunkPos) mgl64.Vec3 {
 // any Entity found in the 3x3 column upwards from the mgl64.Vec3. If multiple
 // entities are found, the position of one of the entities is selected
 // randomly.
-func (w weather) adjustPositionToEntities(tx *Tx, vec mgl64.Vec3) mgl64.Vec3 {
+func (w weather) adjustPositionToEntities(tx *Context, vec mgl64.Vec3) mgl64.Vec3 {
 	max := vec.Add(mgl64.Vec3{0, float64(w.w.Range().Max())})
 
 	list := make([]mgl64.Vec3, 0, 16)

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/internal/sliceutil"
 	"github.com/df-mc/dragonfly/server/world/chunk"
 	"github.com/df-mc/dragonfly/server/world/redstone"
@@ -35,6 +34,16 @@ type World struct {
 	queueClosing chan struct{}
 	queueing     sync.WaitGroup
 
+	// scheduleMu serialises task scheduling against the close transitions
+	// below. scheduling counts in-flight scheduled work that close must drain.
+	scheduleMu sync.Mutex
+	scheduling sync.WaitGroup
+	// closed flips once close starts; new tasks fail with ErrWorldClosed.
+	// closeAcceptingEntityTasks is true only during the close transaction, when
+	// entity Close methods may still schedule final work that close drains.
+	closed                    atomic.Bool
+	closeAcceptingEntityTasks atomic.Bool
+
 	// advance is a bool that specifies if this World should advance the current
 	// tick, time and weather saved in the Settings struct held by the World.
 	advance bool
@@ -46,8 +55,11 @@ type World struct {
 
 	weather
 
-	closing chan struct{}
-	running sync.WaitGroup
+	// closeStarted closes as soon as World.Close begins, before the close
+	// transaction runs; closing closes once the world stops ticking.
+	closeStarted chan struct{}
+	closing      chan struct{}
+	running      sync.WaitGroup
 
 	// chunks holds a cache of chunks currently loaded. These chunks are cleared
 	// from this map after some time of not being used.
@@ -116,15 +128,14 @@ func (w *World) BlockRegistry() BlockRegistry {
 	return w.conf.Blocks
 }
 
-// ExecFunc is a function that performs a synchronised transaction on a World.
-type ExecFunc func(tx *Tx)
+// execFunc is a function that performs a synchronised transaction on a World.
+type execFunc func(tx *Context)
 
-// Exec performs a synchronised transaction f on a World. Exec returns a channel
-// that is closed once the transaction is complete. For Worlds created with
-// Config.Synchronous set, the transaction is executed on the calling goroutine
-// and the channel returned is closed when Exec returns. Awaiting a nested Exec
-// from within a transaction deadlocks on non-synchronous Worlds.
-func (w *World) Exec(f ExecFunc) <-chan struct{} {
+// exec runs f on the World, bypassing the closed check that Do/DoAfter/Call
+// apply — reserved for the World's own machinery (ticking, saving, chunk
+// unload, the close transaction), which must queue work after close begins.
+// The returned channel closes when done; waiting on it from the owner deadlocks.
+func (w *World) exec(f execFunc) <-chan struct{} {
 	c := make(chan struct{})
 	ntx := normalTransaction{c: c, f: f}
 	if w.conf.Synchronous {
@@ -135,23 +146,47 @@ func (w *World) Exec(f ExecFunc) <-chan struct{} {
 	return c
 }
 
-func (w *World) weakExec(invalid *atomic.Bool, cond *sync.Cond, f ExecFunc) <-chan bool {
+func (w *World) weakExec(valid func() bool, cond *sync.Cond, f execFunc, allowClosed bool) <-chan bool {
 	c := make(chan bool, 1)
 	if w.conf.Synchronous {
-		valid := !invalid.Load()
-		if valid {
+		run := valid == nil || valid()
+		if run {
 			// As in weakTransaction.Run, f must not run under cond.L: it may
 			// relock it, e.g. through RemoveEntity.
 			cond.L.Unlock()
-			tx := &Tx{w: w}
-			f(tx)
-			tx.close()
+			ctx := newContext(w)
+			f(ctx)
+			ctx.close()
+			ctx.runDeferred()
 			cond.L.Lock()
 		}
-		c <- valid
+		c <- run
 		return c
 	}
-	w.queue <- weakTransaction{c: c, f: f, invalid: invalid, cond: cond}
+	w.scheduleMu.Lock()
+	if w.closed.Load() && !w.closeAcceptingEntityTasks.Load() && !allowClosed {
+		w.scheduleMu.Unlock()
+		c <- false
+		return c
+	}
+	wtx := weakTransaction{c: c, f: f, valid: valid, cond: cond}
+	select {
+	case w.queue <- wtx:
+		w.scheduleMu.Unlock()
+	default:
+		w.scheduling.Add(1)
+		w.scheduleMu.Unlock()
+		go func() {
+			defer w.scheduling.Done()
+			select {
+			case w.queue <- wtx:
+			case <-w.closing:
+				wtx.fail()
+			case <-w.queueClosing:
+				wtx.fail()
+			}
+		}()
+	}
 	return c
 }
 
@@ -699,8 +734,8 @@ func (w *World) addParticle(pos mgl64.Vec3, p Particle) {
 
 // playSound plays a sound at a specific position in the World. Viewers of that
 // position will be able to hear the sound if they are close enough.
-func (w *World) playSound(tx *Tx, pos mgl64.Vec3, s Sound) {
-	ctx := event.C(tx)
+func (w *World) playSound(tx *Context, pos mgl64.Vec3, s Sound) {
+	ctx := tx.Event()
 	if w.Handler().HandleSound(ctx, s, pos); ctx.Cancelled() {
 		return
 	}
@@ -715,7 +750,7 @@ func (w *World) playSound(tx *Tx, pos mgl64.Vec3, s Sound) {
 // the chunk that the EntityHandle is in is not yet loaded, it will first be
 // loaded. addEntity panics if the EntityHandle is already in a world.
 // addEntity returns the Entity created by the EntityHandle.
-func (w *World) addEntity(tx *Tx, handle *EntityHandle) Entity {
+func (w *World) addEntity(tx *Context, handle *EntityHandle) Entity {
 	handle.setAndUnlockWorld(w)
 	pos := chunkPosFromVec3(handle.data.Pos)
 	w.entities[handle] = pos
@@ -728,7 +763,8 @@ func (w *World) addEntity(tx *Tx, handle *EntityHandle) Entity {
 		// Show the entity to all viewers in the chunk of the entity.
 		showEntity(e, v)
 	}
-	w.Handler().HandleEntitySpawn(tx, e)
+	w.Handler().HandleEntitySpawn(tx.Event(), e)
+	handle.markWorldReady(w)
 	return e
 }
 
@@ -736,14 +772,14 @@ func (w *World) addEntity(tx *Tx, handle *EntityHandle) Entity {
 // it. Any viewers of the Entity will no longer be able to see it.
 // removeEntity returns the EntityHandle of the Entity. After removing an Entity
 // from the World, the Entity is no longer usable.
-func (w *World) removeEntity(e Entity, tx *Tx) *EntityHandle {
+func (w *World) removeEntity(e Entity, tx *Context) *EntityHandle {
 	handle := e.H()
 	pos, found := w.entities[handle]
 	if !found {
 		// The entity currently isn't in this world.
 		return nil
 	}
-	w.Handler().HandleEntityDespawn(tx, e)
+	w.Handler().HandleEntityDespawn(tx.Event(), e)
 
 	c := w.chunk(pos)
 	c.Entities, c.modified = sliceutil.DeleteVal(c.Entities, handle), true
@@ -775,7 +811,7 @@ func (w *World) removeEntityFromViewLayers(e Entity) {
 
 // entitiesWithin returns an iterator that yields all entities contained within
 // the cube.BBox passed.
-func (w *World) entitiesWithin(tx *Tx, box cube.BBox) iter.Seq[Entity] {
+func (w *World) entitiesWithin(tx *Context, box cube.BBox) iter.Seq[Entity] {
 	return func(yield func(Entity) bool) {
 		minPos, maxPos := chunkPosFromVec3(box.Min()), chunkPosFromVec3(box.Max())
 
@@ -801,7 +837,7 @@ func (w *World) entitiesWithin(tx *Tx, box cube.BBox) iter.Seq[Entity] {
 }
 
 // allEntities returns an iterator that yields all entities in the World.
-func (w *World) allEntities(tx *Tx) iter.Seq[Entity] {
+func (w *World) allEntities(tx *Context) iter.Seq[Entity] {
 	return func(yield func(Entity) bool) {
 		for e := range w.entities {
 			if ent := e.mustEntity(tx); !yield(ent) {
@@ -812,7 +848,7 @@ func (w *World) allEntities(tx *Tx) iter.Seq[Entity] {
 }
 
 // allPlayers returns an iterator that yields all player entities in the World.
-func (w *World) allPlayers(tx *Tx) iter.Seq[Entity] {
+func (w *World) allPlayers(tx *Context) iter.Seq[Entity] {
 	return func(yield func(Entity) bool) {
 		for e := range w.entities {
 			if e.t.EncodeEntity() == "minecraft:player" {
@@ -1043,12 +1079,12 @@ func (w *World) PortalDestination(dim Dimension) *World {
 
 // Save saves the World to the provider.
 func (w *World) Save() {
-	<-w.Exec(w.save(w.saveChunk))
+	<-w.exec(w.save(w.saveChunk))
 }
 
 // save saves all loaded chunks to the World's provider.
-func (w *World) save(f func(*Tx, ChunkPos, *Column)) ExecFunc {
-	return func(tx *Tx) {
+func (w *World) save(f func(*Context, ChunkPos, *Column)) execFunc {
+	return func(tx *Context) {
 		if w.conf.ReadOnly {
 			return
 		}
@@ -1062,7 +1098,7 @@ func (w *World) save(f func(*Tx, ChunkPos, *Column)) ExecFunc {
 }
 
 // saveChunk saves a chunk and its entities to disk after compacting the chunk.
-func (w *World) saveChunk(_ *Tx, pos ChunkPos, c *Column) {
+func (w *World) saveChunk(_ *Context, pos ChunkPos, c *Column) {
 	if !w.conf.ReadOnly && c.modified {
 		c.Compact()
 		if err := w.conf.Provider.StoreColumn(pos, w.conf.Dim, w.columnTo(c, pos)); err != nil {
@@ -1074,7 +1110,7 @@ func (w *World) saveChunk(_ *Tx, pos ChunkPos, c *Column) {
 // closeChunk saves a chunk and its entities to disk after compacting the chunk.
 // Afterwards, scheduled updates from that chunk are removed and all entities
 // in it are closed.
-func (w *World) closeChunk(tx *Tx, pos ChunkPos, c *Column) {
+func (w *World) closeChunk(tx *Context, pos ChunkPos, c *Column) {
 	w.saveChunk(tx, pos, c)
 	w.scheduledUpdates.removeChunk(pos)
 	// Note: We close c.Entities here because some entities may remove
@@ -1096,13 +1132,27 @@ func (w *World) Close() error {
 // close stops the World from ticking, saves all chunks to the Provider and
 // updates the world's settings.
 func (w *World) close() {
-	<-w.Exec(func(tx *Tx) {
+	w.scheduleMu.Lock()
+	w.closed.Store(true)
+	close(w.closeStarted)
+	w.scheduleMu.Unlock()
+
+	w.scheduling.Wait()
+	w.scheduleMu.Lock()
+	w.closeAcceptingEntityTasks.Store(true)
+	w.scheduleMu.Unlock()
+	<-w.exec(func(tx *Context) {
 		// Let user code run anything that needs to be finished before closing.
 		w.Handler().HandleClose(tx)
+		tx.runDeferred()
 		w.Handle(NopHandler{})
 
 		w.save(w.closeChunk)(tx)
 	})
+	w.scheduleMu.Lock()
+	w.closeAcceptingEntityTasks.Store(false)
+	w.scheduleMu.Unlock()
+	w.scheduling.Wait()
 
 	close(w.closing)
 	w.running.Wait()
@@ -1152,7 +1202,7 @@ func (w *World) addWorldViewer(l *Loader) {
 // addViewer adds a viewer to the World at a given position. Any events that
 // happen in the chunk at that position, such as block and entity changes, will
 // be sent to the viewer.
-func (w *World) addViewer(tx *Tx, c *Column, loader *Loader) {
+func (w *World) addViewer(tx *Context, c *Column, loader *Loader) {
 	c.viewers = append(c.viewers, loader.viewer)
 	c.loaders = append(c.loaders, loader)
 
@@ -1164,7 +1214,7 @@ func (w *World) addViewer(tx *Tx, c *Column, loader *Loader) {
 // removeViewer removes a viewer from a chunk position. All entities will be
 // hidden from the viewer and no more calls will be made when events in the
 // chunk happen.
-func (w *World) removeViewer(tx *Tx, pos ChunkPos, loader *Loader) {
+func (w *World) removeViewer(tx *Context, pos ChunkPos, loader *Loader) {
 	if w == nil {
 		return
 	}
@@ -1228,7 +1278,8 @@ func (w *World) loadChunk(pos ChunkPos) (*Column, error) {
 		w.chunks[pos] = col
 		for _, e := range col.Entities {
 			w.entities[e] = pos
-			e.w = w
+			e.setAndUnlockWorld(w)
+			e.markWorldReady(w)
 		}
 		return col, nil
 	case errors.Is(err, leveldb.ErrNotFound):
@@ -1293,7 +1344,7 @@ func (w *World) autoSave() {
 	for {
 		select {
 		case <-closeUnused.C:
-			<-w.Exec(w.closeUnusedChunks)
+			<-w.exec(w.closeUnusedChunks)
 		case <-save.C:
 			w.Save()
 		case <-w.closing:
@@ -1304,7 +1355,7 @@ func (w *World) autoSave() {
 }
 
 // closeUnusedChunk closes all chunks currently not in use by any viewer.
-func (w *World) closeUnusedChunks(tx *Tx) {
+func (w *World) closeUnusedChunks(tx *Context) {
 	for pos, c := range w.chunks {
 		if len(c.viewers) == 0 {
 			w.closeChunk(tx, pos, c)

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -129,7 +129,7 @@ func (w *World) BlockRegistry() BlockRegistry {
 }
 
 // execFunc is a function that performs a synchronised transaction on a World.
-type execFunc func(tx *Context)
+type execFunc func(tx *Tx)
 
 // exec runs f on the World, bypassing the closed check that Do/DoAfter/Call
 // apply — reserved for the World's own machinery (ticking, saving, chunk
@@ -154,10 +154,10 @@ func (w *World) weakExec(valid func() bool, cond *sync.Cond, f execFunc, allowCl
 			// As in weakTransaction.Run, f must not run under cond.L: it may
 			// relock it, e.g. through RemoveEntity.
 			cond.L.Unlock()
-			ctx := newContext(w)
-			f(ctx)
-			ctx.close()
-			ctx.runDeferred()
+			tx := newTx(w)
+			f(tx)
+			tx.close()
+			tx.runDeferred()
 			cond.L.Lock()
 		}
 		c <- run
@@ -734,7 +734,7 @@ func (w *World) addParticle(pos mgl64.Vec3, p Particle) {
 
 // playSound plays a sound at a specific position in the World. Viewers of that
 // position will be able to hear the sound if they are close enough.
-func (w *World) playSound(tx *Context, pos mgl64.Vec3, s Sound) {
+func (w *World) playSound(tx *Tx, pos mgl64.Vec3, s Sound) {
 	ctx := tx.Event()
 	if w.Handler().HandleSound(ctx, s, pos); ctx.Cancelled() {
 		return
@@ -750,7 +750,7 @@ func (w *World) playSound(tx *Context, pos mgl64.Vec3, s Sound) {
 // the chunk that the EntityHandle is in is not yet loaded, it will first be
 // loaded. addEntity panics if the EntityHandle is already in a world.
 // addEntity returns the Entity created by the EntityHandle.
-func (w *World) addEntity(tx *Context, handle *EntityHandle) Entity {
+func (w *World) addEntity(tx *Tx, handle *EntityHandle) Entity {
 	handle.setAndUnlockWorld(w)
 	pos := chunkPosFromVec3(handle.data.Pos)
 	w.entities[handle] = pos
@@ -763,7 +763,7 @@ func (w *World) addEntity(tx *Context, handle *EntityHandle) Entity {
 		// Show the entity to all viewers in the chunk of the entity.
 		showEntity(e, v)
 	}
-	w.Handler().HandleEntitySpawn(tx.Event(), e)
+	w.Handler().HandleEntitySpawn(tx, e)
 	handle.markWorldReady(w)
 	return e
 }
@@ -772,14 +772,14 @@ func (w *World) addEntity(tx *Context, handle *EntityHandle) Entity {
 // it. Any viewers of the Entity will no longer be able to see it.
 // removeEntity returns the EntityHandle of the Entity. After removing an Entity
 // from the World, the Entity is no longer usable.
-func (w *World) removeEntity(e Entity, tx *Context) *EntityHandle {
+func (w *World) removeEntity(e Entity, tx *Tx) *EntityHandle {
 	handle := e.H()
 	pos, found := w.entities[handle]
 	if !found {
 		// The entity currently isn't in this world.
 		return nil
 	}
-	w.Handler().HandleEntityDespawn(tx.Event(), e)
+	w.Handler().HandleEntityDespawn(tx, e)
 
 	c := w.chunk(pos)
 	c.Entities, c.modified = sliceutil.DeleteVal(c.Entities, handle), true
@@ -811,7 +811,7 @@ func (w *World) removeEntityFromViewLayers(e Entity) {
 
 // entitiesWithin returns an iterator that yields all entities contained within
 // the cube.BBox passed.
-func (w *World) entitiesWithin(tx *Context, box cube.BBox) iter.Seq[Entity] {
+func (w *World) entitiesWithin(tx *Tx, box cube.BBox) iter.Seq[Entity] {
 	return func(yield func(Entity) bool) {
 		minPos, maxPos := chunkPosFromVec3(box.Min()), chunkPosFromVec3(box.Max())
 
@@ -837,7 +837,7 @@ func (w *World) entitiesWithin(tx *Context, box cube.BBox) iter.Seq[Entity] {
 }
 
 // allEntities returns an iterator that yields all entities in the World.
-func (w *World) allEntities(tx *Context) iter.Seq[Entity] {
+func (w *World) allEntities(tx *Tx) iter.Seq[Entity] {
 	return func(yield func(Entity) bool) {
 		for e := range w.entities {
 			if ent := e.mustEntity(tx); !yield(ent) {
@@ -848,7 +848,7 @@ func (w *World) allEntities(tx *Context) iter.Seq[Entity] {
 }
 
 // allPlayers returns an iterator that yields all player entities in the World.
-func (w *World) allPlayers(tx *Context) iter.Seq[Entity] {
+func (w *World) allPlayers(tx *Tx) iter.Seq[Entity] {
 	return func(yield func(Entity) bool) {
 		for e := range w.entities {
 			if e.t.EncodeEntity() == "minecraft:player" {
@@ -1083,8 +1083,8 @@ func (w *World) Save() {
 }
 
 // save saves all loaded chunks to the World's provider.
-func (w *World) save(f func(*Context, ChunkPos, *Column)) execFunc {
-	return func(tx *Context) {
+func (w *World) save(f func(*Tx, ChunkPos, *Column)) execFunc {
+	return func(tx *Tx) {
 		if w.conf.ReadOnly {
 			return
 		}
@@ -1098,7 +1098,7 @@ func (w *World) save(f func(*Context, ChunkPos, *Column)) execFunc {
 }
 
 // saveChunk saves a chunk and its entities to disk after compacting the chunk.
-func (w *World) saveChunk(_ *Context, pos ChunkPos, c *Column) {
+func (w *World) saveChunk(_ *Tx, pos ChunkPos, c *Column) {
 	if !w.conf.ReadOnly && c.modified {
 		c.Compact()
 		if err := w.conf.Provider.StoreColumn(pos, w.conf.Dim, w.columnTo(c, pos)); err != nil {
@@ -1110,7 +1110,7 @@ func (w *World) saveChunk(_ *Context, pos ChunkPos, c *Column) {
 // closeChunk saves a chunk and its entities to disk after compacting the chunk.
 // Afterwards, scheduled updates from that chunk are removed and all entities
 // in it are closed.
-func (w *World) closeChunk(tx *Context, pos ChunkPos, c *Column) {
+func (w *World) closeChunk(tx *Tx, pos ChunkPos, c *Column) {
 	w.saveChunk(tx, pos, c)
 	w.scheduledUpdates.removeChunk(pos)
 	// Note: We close c.Entities here because some entities may remove
@@ -1141,7 +1141,7 @@ func (w *World) close() {
 	w.scheduleMu.Lock()
 	w.closeAcceptingEntityTasks.Store(true)
 	w.scheduleMu.Unlock()
-	<-w.exec(func(tx *Context) {
+	<-w.exec(func(tx *Tx) {
 		// Let user code run anything that needs to be finished before closing.
 		w.Handler().HandleClose(tx)
 		tx.runDeferred()
@@ -1202,7 +1202,7 @@ func (w *World) addWorldViewer(l *Loader) {
 // addViewer adds a viewer to the World at a given position. Any events that
 // happen in the chunk at that position, such as block and entity changes, will
 // be sent to the viewer.
-func (w *World) addViewer(tx *Context, c *Column, loader *Loader) {
+func (w *World) addViewer(tx *Tx, c *Column, loader *Loader) {
 	c.viewers = append(c.viewers, loader.viewer)
 	c.loaders = append(c.loaders, loader)
 
@@ -1214,7 +1214,7 @@ func (w *World) addViewer(tx *Context, c *Column, loader *Loader) {
 // removeViewer removes a viewer from a chunk position. All entities will be
 // hidden from the viewer and no more calls will be made when events in the
 // chunk happen.
-func (w *World) removeViewer(tx *Context, pos ChunkPos, loader *Loader) {
+func (w *World) removeViewer(tx *Tx, pos ChunkPos, loader *Loader) {
 	if w == nil {
 		return
 	}
@@ -1355,7 +1355,7 @@ func (w *World) autoSave() {
 }
 
 // closeUnusedChunk closes all chunks currently not in use by any viewer.
-func (w *World) closeUnusedChunks(tx *Context) {
+func (w *World) closeUnusedChunks(tx *Tx) {
 	for pos, c := range w.chunks {
 		if len(c.viewers) == 0 {
 			w.closeChunk(tx, pos, c)

--- a/server/world/world_test.go
+++ b/server/world/world_test.go
@@ -17,7 +17,7 @@ func TestSynchronousWorldDo(t *testing.T) {
 	defer w.Close()
 
 	var ran bool
-	task := w.Do(func(ctx *Context) { ran = true })
+	task := w.Do(func(tx *Tx) { ran = true })
 	if !ran {
 		t.Fatal("expected task to have run when Do returned")
 	}
@@ -58,11 +58,11 @@ func TestSynchronousEntityDoCanRemoveEntity(t *testing.T) {
 	defer w.Close()
 
 	h := EntitySpawnOpts{Position: mgl64.Vec3{0, 4, 0}}.New(testEntityType{}, testEntityConfig{})
-	<-w.exec(func(tx *Context) {
+	<-w.exec(func(tx *Tx) {
 		tx.AddEntity(h)
 	})
 
-	task := h.Do(func(tx *Context, e Entity) {
+	task := h.Do(func(tx *Tx, e Entity) {
 		tx.RemoveEntity(e)
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -82,10 +82,10 @@ func TestSynchronousEntityDoWaitsForAddEntityToFinish(t *testing.T) {
 		release:    make(chan struct{}),
 	}
 	h := EntitySpawnOpts{}.New(blockingOpenType{}, blockingOpenConfig{state: state})
-	task := h.Do(func(*Context, Entity) {})
+	task := h.Do(func(*Tx, Entity) {})
 	added := make(chan struct{})
 	go func() {
-		w.Do(func(tx *Context) { tx.AddEntity(h) })
+		w.Do(func(tx *Tx) { tx.AddEntity(h) })
 		close(added)
 	}()
 	<-state.firstOpen
@@ -111,7 +111,7 @@ func TestSynchronousAdvanceTickTicksViewerlessEntities(t *testing.T) {
 	defer w.Close()
 
 	h := EntitySpawnOpts{Position: mgl64.Vec3{0, 4, 0}}.New(testEntityType{}, testEntityConfig{})
-	<-w.exec(func(tx *Context) {
+	<-w.exec(func(tx *Tx) {
 		tx.AddEntity(h)
 	})
 
@@ -130,7 +130,7 @@ func TestSynchronousAdvanceTickTicksViewerlessBlockEntities(t *testing.T) {
 
 	pos := cube.Pos{0, 4, 0}
 	tb := &testTickerBlock{}
-	<-w.exec(func(tx *Context) {
+	<-w.exec(func(tx *Tx) {
 		col := tx.World().chunk(chunkPosFromBlockPos(pos))
 		chest, ok := tx.World().conf.Blocks.BlockByName("minecraft:chest", map[string]any{"minecraft:cardinal_direction": "north"})
 		if !ok {
@@ -152,7 +152,7 @@ func (testEntityConfig) Apply(*EntityData) {}
 
 type testEntityType struct{}
 
-func (testEntityType) Open(_ *Context, handle *EntityHandle, data *EntityData) Entity {
+func (testEntityType) Open(_ *Tx, handle *EntityHandle, data *EntityData) Entity {
 	return &testEntity{handle: handle, data: data}
 }
 
@@ -191,7 +191,7 @@ func (e *testEntity) Rotation() cube.Rotation {
 	return e.data.Rot
 }
 
-func (e *testEntity) Tick(*Context, int64) {
+func (e *testEntity) Tick(*Tx, int64) {
 	e.data.Pos = e.data.Pos.Add(mgl64.Vec3{0, -0.1, 0})
 }
 
@@ -214,7 +214,7 @@ func (c blockingOpenConfig) Apply(data *EntityData) { data.Data = c.state }
 
 type blockingOpenType struct{}
 
-func (blockingOpenType) Open(_ *Context, handle *EntityHandle, data *EntityData) Entity {
+func (blockingOpenType) Open(_ *Tx, handle *EntityHandle, data *EntityData) Entity {
 	state := data.Data.(*blockingOpenState)
 	switch state.opens.Add(1) {
 	case 1:
@@ -254,6 +254,6 @@ func (*testTickerBlock) EncodeNBT() map[string]any {
 	return nil
 }
 
-func (b *testTickerBlock) Tick(int64, cube.Pos, *Context) {
+func (b *testTickerBlock) Tick(int64, cube.Pos, *Tx) {
 	b.ticks++
 }

--- a/server/world/world_test.go
+++ b/server/world/world_test.go
@@ -1,6 +1,8 @@
 package world
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -8,22 +10,21 @@ import (
 	"github.com/go-gl/mathgl/mgl64"
 )
 
-// TestSynchronousWorldExec verifies that Exec on a synchronous World runs the
-// transaction on the calling goroutine, with the returned channel closed once
-// Exec returns.
-func TestSynchronousWorldExec(t *testing.T) {
+// TestSynchronousWorldDo verifies that Do on a synchronous World runs the task
+// on the calling goroutine and returns a completed task.
+func TestSynchronousWorldDo(t *testing.T) {
 	w := Config{Synchronous: true}.New()
 	defer w.Close()
 
 	var ran bool
-	c := w.Exec(func(tx *Tx) { ran = true })
+	task := w.Do(func(ctx *Context) { ran = true })
 	if !ran {
-		t.Fatal("expected transaction to have run when Exec returned")
+		t.Fatal("expected task to have run when Do returned")
 	}
 	select {
-	case <-c:
+	case <-task.Done():
 	default:
-		t.Fatal("expected channel returned by Exec to be closed when Exec returned")
+		t.Fatal("expected task returned by Do to be done when Do returned")
 	}
 }
 
@@ -52,26 +53,56 @@ func TestSynchronousWorldAdvanceTick(t *testing.T) {
 	}
 }
 
-func TestSynchronousExecWorldCanRemoveEntity(t *testing.T) {
+func TestSynchronousEntityDoCanRemoveEntity(t *testing.T) {
 	w := Config{Synchronous: true}.New()
 	defer w.Close()
 
 	h := EntitySpawnOpts{Position: mgl64.Vec3{0, 4, 0}}.New(testEntityType{}, testEntityConfig{})
-	<-w.Exec(func(tx *Tx) {
+	<-w.exec(func(tx *Context) {
 		tx.AddEntity(h)
 	})
 
-	done := make(chan struct{})
+	task := h.Do(func(tx *Context, e Entity) {
+		tx.RemoveEntity(e)
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	if err := task.Wait(ctx); err != nil {
+		t.Fatalf("entity Do self-removal did not complete: %v", err)
+	}
+}
+
+func TestSynchronousEntityDoWaitsForAddEntityToFinish(t *testing.T) {
+	w := Config{Synchronous: true}.New()
+	defer w.Close()
+
+	state := &blockingOpenState{
+		firstOpen:  make(chan struct{}),
+		secondOpen: make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	h := EntitySpawnOpts{}.New(blockingOpenType{}, blockingOpenConfig{state: state})
+	task := h.Do(func(*Context, Entity) {})
+	added := make(chan struct{})
 	go func() {
-		h.ExecWorld(func(tx *Tx, e Entity) {
-			tx.RemoveEntity(e)
-		})
-		close(done)
+		w.Do(func(tx *Context) { tx.AddEntity(h) })
+		close(added)
 	}()
+	<-state.firstOpen
+
+	premature := false
 	select {
-	case <-done:
-	case <-time.After(time.Second * 5):
-		t.Fatal("ExecWorld self-removal did not complete")
+	case <-state.secondOpen:
+		premature = true
+	case <-time.After(time.Millisecond * 50):
+	}
+	close(state.release)
+	<-added
+	if err := task.Wait(context.Background()); err != nil {
+		t.Fatalf("entity Do failed: %v", err)
+	}
+	if premature {
+		t.Fatal("entity callback opened before AddEntity completed")
 	}
 }
 
@@ -80,7 +111,7 @@ func TestSynchronousAdvanceTickTicksViewerlessEntities(t *testing.T) {
 	defer w.Close()
 
 	h := EntitySpawnOpts{Position: mgl64.Vec3{0, 4, 0}}.New(testEntityType{}, testEntityConfig{})
-	<-w.Exec(func(tx *Tx) {
+	<-w.exec(func(tx *Context) {
 		tx.AddEntity(h)
 	})
 
@@ -99,7 +130,7 @@ func TestSynchronousAdvanceTickTicksViewerlessBlockEntities(t *testing.T) {
 
 	pos := cube.Pos{0, 4, 0}
 	tb := &testTickerBlock{}
-	<-w.Exec(func(tx *Tx) {
+	<-w.exec(func(tx *Context) {
 		col := tx.World().chunk(chunkPosFromBlockPos(pos))
 		chest, ok := tx.World().conf.Blocks.BlockByName("minecraft:chest", map[string]any{"minecraft:cardinal_direction": "north"})
 		if !ok {
@@ -121,7 +152,7 @@ func (testEntityConfig) Apply(*EntityData) {}
 
 type testEntityType struct{}
 
-func (testEntityType) Open(_ *Tx, handle *EntityHandle, data *EntityData) Entity {
+func (testEntityType) Open(_ *Context, handle *EntityHandle, data *EntityData) Entity {
 	return &testEntity{handle: handle, data: data}
 }
 
@@ -160,13 +191,48 @@ func (e *testEntity) Rotation() cube.Rotation {
 	return e.data.Rot
 }
 
-func (e *testEntity) Tick(*Tx, int64) {
+func (e *testEntity) Tick(*Context, int64) {
 	e.data.Pos = e.data.Pos.Add(mgl64.Vec3{0, -0.1, 0})
 }
 
 type testTickerBlock struct {
 	ticks int
 }
+
+type blockingOpenState struct {
+	opens      atomic.Int32
+	firstOpen  chan struct{}
+	secondOpen chan struct{}
+	release    chan struct{}
+}
+
+type blockingOpenConfig struct {
+	state *blockingOpenState
+}
+
+func (c blockingOpenConfig) Apply(data *EntityData) { data.Data = c.state }
+
+type blockingOpenType struct{}
+
+func (blockingOpenType) Open(_ *Context, handle *EntityHandle, data *EntityData) Entity {
+	state := data.Data.(*blockingOpenState)
+	switch state.opens.Add(1) {
+	case 1:
+		close(state.firstOpen)
+		<-state.release
+	case 2:
+		close(state.secondOpen)
+	}
+	return &testEntity{handle: handle, data: data}
+}
+
+func (blockingOpenType) EncodeEntity() string { return "dragonfly:blocking_open" }
+
+func (blockingOpenType) BBox(Entity) cube.BBox { return cube.BBox{} }
+
+func (blockingOpenType) DecodeNBT(map[string]any, *EntityData) {}
+
+func (blockingOpenType) EncodeNBT(*EntityData) map[string]any { return nil }
 
 func (*testTickerBlock) EncodeBlock() (string, map[string]any) {
 	return "dragonfly:test_ticker", nil
@@ -188,6 +254,6 @@ func (*testTickerBlock) EncodeNBT() map[string]any {
 	return nil
 }
 
-func (b *testTickerBlock) Tick(int64, cube.Pos, *Tx) {
+func (b *testTickerBlock) Tick(int64, cube.Pos, *Context) {
 	b.ticks++
 }


### PR DESCRIPTION
## Summary

`World.Exec` and `EntityHandle.ExecWorld` make it easy for user code to self-deadlock: a blocking call that is safe from an outside goroutine deadlocks inside an event handler, command or packet callback that is already running on that world's owner (the single goroutine that runs all of a world's transactions), and it is often not obvious which of the two a given function is. This PR replaces them with owner-scoped scheduling as the public re-entry path (full design rationale with repository evidence: [HashimTheArab/dragonfly#33](https://github.com/HashimTheArab/dragonfly/issues/33)):

- **`world.Tx`** remains what it has always been — the handle a callback holds while it has exclusive, serialized access to the world — and owns all world operations; the ~250 existing `*world.Tx` gameplay signatures are unchanged and final. **`world.Context`** becomes a small cancellable event scope embedding `*Tx`, created per handler dispatch via `Tx.Event()`, so cancelling one event cannot affect another fired in the same tick — and non-cancellable events (`HandleEntitySpawn`, `HandleEntityDespawn`, `HandleClose`) take `*Tx` directly, making a no-op `Cancel()` unrepresentable.
- **Fire-and-forget scheduling**: `World.Do`/`DoAfter`, `EntityHandle.Do`/`DoAfter`, typed `world.EntityRef[T]`, `player.Ref`/`Player.Do`/`DoAfter` and `Context.Defer`. Entity tasks follow the entity across world changes and fail with defined errors (`ErrEntityClosed`, `ErrWorldClosed`, `ErrEntityType`) when the entity or world closes first.
- **Blocking request/response for off-owner code**: `world.Call`/`CallEntity`/`CallRef` return a typed result and a `*world.Task` handle (`Done`/`Err`/`Wait`/`OnDone`/`Cancel`). Callback panics are captured into `world.PanicError` (with stack), logged through the world logger, and re-panicked on session-facing paths so they still surface loudly.
- **Migrated internals**: sessions, server join and player iteration, respawn/disconnect and delayed actions (goat horn, death timing) run on the new paths with defined behaviour when a world or entity closes mid-flight. World close drains in-flight scheduled work in a defined order before saving. Commands may run with a nil `*world.Tx` when the source is not attached to a world.

## Migration

```go
// Before: blocks, and deadlocks if already inside this world's owner.
<-w.Exec(func(tx *world.Tx) {
    tx.SetBlock(pos, block.Stone{}, nil)
})

// After: fire-and-forget from anywhere.
w.Do(func(tx *world.Tx) {
    tx.SetBlock(pos, block.Stone{}, nil)
})

// Off-owner code that needs a result:
count, err := world.Call(ctx, w, func(tx *world.Tx) (int, error) { ... })

// Delayed entity work follows the entity across worlds:
handle.DoAfter(time.Second, func(tx *world.Tx, e world.Entity) { ... })

// Typed player re-entry from outside a callback:
player.Do(handle, func(tx *world.Tx, p *player.Player) {
    p.Message("hello")
})
```

Inside handlers and commands nothing changes: the callback context is already the owner, so world operations are used directly. `player.Context` now embeds `*world.Context`, so player event handlers can do world operations straight off the event context.

## Breaking changes

- `World.Exec` and `EntityHandle.ExecWorld` are removed (replaced by `Do`/`Call*` above).
- `world.Context`/`player.Context` become concrete event-scope types replacing the `event.Context` aliases; `ctx.Val()` becomes `ctx.Player()` for player events, and world operations are available directly on the event context. `HandleEntitySpawn`/`HandleEntityDespawn`/`HandleClose` now take `*world.Tx` (they were never cancellable).
- `session.Config.HandleStop` may now receive a nil `*world.Tx` for a controllable that could not be restored to any world during teardown.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race -count=2 ./server/world ./server/session ./server/player`.
- Regression tests are kept for the invariants that are easiest to silently break: owner-queue-full deadlocks (both the task and weak-transaction paths), close-drain ordering, weak-transaction cancellation, and the AddEntity/scheduled-callback handoff.
