### PR TITLE
entity: stop ticking items collected by hoppers

### DIFF
--- a/server/entity/item_behaviour.go
+++ b/server/entity/item_behaviour.go
@@ -98,6 +98,7 @@ func (i *ItemBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 		_ = e.Close()
 		bl.CollectCooldown = 8
 		tx.SetBlock(blockPos, bl, nil)
+		return nil
 	}
 	return i.passive.Tick(e, tx)
 }


### PR DESCRIPTION
Fixes #1311.

Item entities collected by a hopper were closed and removed, but their passive behaviour still ran for the rest of that tick. Once their pickup delay elapsed, the removed entity could merge with another nearby item and recreate items that had already entered the hopper.

Return immediately after successful hopper collection so the closed entity cannot move, merge, or otherwise tick again.

Validation:
- Reproduced the item-count inflation locally before the fix
- Confirmed item conservation locally after the fix
- go test ./...
- codex review --uncommitted