### PR TITLE
session: synchronise persistent sneaking input

### DIFF
--- a/server/session/handler_player_auth_input.go
+++ b/server/session/handler_player_auth_input.go
@@ -104,11 +104,12 @@ func (h PlayerAuthInputHandler) handleInputFlags(flags protocol.Bitset, s *Sessi
 	if flags.Load(packet.InputFlagStopSprinting) {
 		c.StopSprinting()
 	}
-	if flags.Load(packet.InputFlagStartSneaking) {
-		c.StartSneaking()
-	}
-	if flags.Load(packet.InputFlagStopSneaking) {
-		c.StopSneaking()
+	if sneaking := flags.Load(packet.InputFlagSneaking); sneaking != c.Sneaking() {
+		if sneaking {
+			c.StartSneaking()
+		} else {
+			c.StopSneaking()
+		}
 	}
 	if flags.Load(packet.InputFlagStartSwimming) {
 		c.StartSwimming()


### PR DESCRIPTION
Fixes #1310.

Dragonfly only updated sneaking state from the one-shot StartSneaking and StopSneaking transition flags. While flying, Bedrock uses the persistent Sneaking input flag for the held descend/sneak control, so the server could still consider the player non-sneaking when an interactable block was clicked. The server activated the container while the client predicted block placement, leaving a ghost block.

Synchronise the server state from the persistent Sneaking flag whenever it differs from the controllable's current state. This also avoids redundant toggle callbacks.

This matches the persistent-state handling used by other Bedrock server implementations.

Validation:
- go test ./...
- codex review --uncommitted