### PR TITLE
Fix portal scheduling after transaction API change

### DIFF
--- a/server/entity/travel.go
+++ b/server/entity/travel.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -193,14 +194,15 @@ func (t *PortalTravelComputer) travelQueued(e Traveller, tx *world.Tx, destinati
 	h := e.H()
 	go func() {
 		var handle *world.EntityHandle
-		<-source.Exec(func(tx *world.Tx) {
+		_, err := world.Call(context.Background(), source, func(tx *world.Tx) (struct{}, error) {
 			// Re-open the entity in this transaction: the wrapper the travel was queued with belonged to a
 			// transaction that has since finished.
 			if e, ok := h.Entity(tx); ok {
 				handle = tx.RemoveEntity(e)
 			}
+			return struct{}{}, nil
 		})
-		if handle == nil {
+		if err != nil || handle == nil {
 			t.mu.Lock()
 			t.travelling, t.timedOut = false, false
 			t.mu.Unlock()
@@ -214,19 +216,24 @@ func (t *PortalTravelComputer) travelQueued(e Traveller, tx *world.Tx, destinati
 // and the entity may not create one, the entity is returned to its origin in the source world instead.
 func (t *PortalTravelComputer) transfer(handle *world.EntityHandle, source, destination *world.World, origin mgl64.Vec3, pos cube.Pos, sourceDim, destinationDim world.Dimension) {
 	travelled := true
-	<-destination.Exec(func(tx *world.Tx) {
+	_, err := world.Call(context.Background(), destination, func(tx *world.Tx) (struct{}, error) {
 		spawn, ok := t.destinationSpawn(tx, pos)
 		if !ok {
 			travelled = false
-			return
+			return struct{}{}, nil
 		}
 		if e, ok := tx.AddEntityAt(handle, spawn).(Traveller); ok {
 			t.finishTravel(e, spawn, sourceDim, destinationDim)
 		}
+		return struct{}{}, nil
 	})
+	if err != nil {
+		travelled = false
+	}
 	if !travelled {
-		<-source.Exec(func(tx *world.Tx) {
+		_, _ = world.Call(context.Background(), source, func(tx *world.Tx) (struct{}, error) {
 			tx.AddEntityAt(handle, origin)
+			return struct{}{}, nil
 		})
 	}
 

--- a/server/entity/travel.go
+++ b/server/entity/travel.go
@@ -228,6 +228,7 @@ func (t *PortalTravelComputer) transfer(handle *world.EntityHandle, source, dest
 		}
 		return struct{}{}, nil
 	})
+	world.RethrowPanic(err)
 	if err != nil {
 		travelled = false
 	}
@@ -236,6 +237,7 @@ func (t *PortalTravelComputer) transfer(handle *world.EntityHandle, source, dest
 			tx.AddEntityAt(handle, origin)
 			return struct{}{}, nil
 		})
+		world.RethrowPanic(err)
 		if err != nil {
 			_ = handle.Close()
 		}

--- a/server/entity/travel.go
+++ b/server/entity/travel.go
@@ -192,24 +192,25 @@ func (t *PortalTravelComputer) travelQueued(e Traveller, tx *world.Tx, destinati
 	t.mu.Unlock()
 
 	h := e.H()
-	go func() {
-		var handle *world.EntityHandle
-		_, err := world.Call(context.Background(), source, func(tx *world.Tx) (struct{}, error) {
-			// Re-open the entity in this transaction: the wrapper the travel was queued with belonged to a
-			// transaction that has since finished.
-			if e, ok := h.Entity(tx); ok {
-				handle = tx.RemoveEntity(e)
-			}
-			return struct{}{}, nil
-		})
-		if err != nil || handle == nil {
+	tx.Defer(func(tx *world.Tx) {
+		// Re-open the entity in the deferred transaction: The wrapper passed to travelQueued belongs to the
+		// transaction that is about to finish.
+		e, ok := h.Entity(tx)
+		if !ok {
 			t.mu.Lock()
 			t.travelling, t.timedOut = false, false
 			t.mu.Unlock()
 			return
 		}
-		t.transfer(handle, source, destination, origin, pos, sourceDim, destinationDim)
-	}()
+		handle := tx.RemoveEntity(e)
+		if handle == nil {
+			t.mu.Lock()
+			t.travelling, t.timedOut = false, false
+			t.mu.Unlock()
+			return
+		}
+		go t.transfer(handle, source, destination, origin, pos, sourceDim, destinationDim)
+	})
 }
 
 // transfer adds the removed entity to the destination world at the linked portal. If no destination portal was found
@@ -231,10 +232,13 @@ func (t *PortalTravelComputer) transfer(handle *world.EntityHandle, source, dest
 		travelled = false
 	}
 	if !travelled {
-		_, _ = world.Call(context.Background(), source, func(tx *world.Tx) (struct{}, error) {
+		_, err = world.Call(context.Background(), source, func(tx *world.Tx) (struct{}, error) {
 			tx.AddEntityAt(handle, origin)
 			return struct{}{}, nil
 		})
+		if err != nil {
+			_ = handle.Close()
+		}
 	}
 
 	t.mu.Lock()

--- a/server/entity/travel.go
+++ b/server/entity/travel.go
@@ -216,19 +216,16 @@ func (t *PortalTravelComputer) travelQueued(e Traveller, tx *world.Tx, destinati
 // transfer adds the removed entity to the destination world at the linked portal. If no destination portal was found
 // and the entity may not create one, the entity is returned to its origin in the source world instead.
 func (t *PortalTravelComputer) transfer(handle *world.EntityHandle, source, destination *world.World, origin mgl64.Vec3, pos cube.Pos, sourceDim, destinationDim world.Dimension) {
-	travelled := true
-	_, err := world.Call(context.Background(), destination, func(tx *world.Tx) (struct{}, error) {
+	travelled, err := world.Call(context.Background(), destination, func(tx *world.Tx) (bool, error) {
 		spawn, ok := t.destinationSpawn(tx, pos)
 		if !ok {
-			travelled = false
-			return struct{}{}, nil
+			return false, nil
 		}
 		if e, ok := tx.AddEntityAt(handle, spawn).(Traveller); ok {
 			t.finishTravel(e, spawn, sourceDim, destinationDim)
 		}
-		return struct{}{}, nil
+		return true, nil
 	})
-	world.RethrowPanic(err)
 	if err != nil {
 		travelled = false
 	}
@@ -237,7 +234,6 @@ func (t *PortalTravelComputer) transfer(handle *world.EntityHandle, source, dest
 			tx.AddEntityAt(handle, origin)
 			return struct{}{}, nil
 		})
-		world.RethrowPanic(err)
 		if err != nil {
 			_ = handle.Close()
 		}

--- a/server/entity/travel_test.go
+++ b/server/entity/travel_test.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -56,12 +57,12 @@ func TestEntProjectileTravelsThroughPortal(t *testing.T) {
 
 	sourcePos := mgl64.Vec3{80.5, 64, 80.5}
 	targetPortal := cube.Pos{10, 64, 10}
-	<-nether.Exec(func(tx *world.Tx) {
+	mustDo(t, nether, func(tx *world.Tx) {
 		buildActivePortal(tx, targetPortal)
 	})
 
 	handle := world.EntitySpawnOpts{Position: sourcePos}.New(EnderPearlType, enderPearlConf)
-	<-overworld.Exec(func(tx *world.Tx) {
+	mustDo(t, overworld, func(tx *world.Tx) {
 		e := tx.AddEntity(handle)
 		(block.Portal{Axis: cube.Z}).EntityInside(cube.PosFromVec3(sourcePos), tx, e)
 		if _, ok := handle.Entity(tx); !ok {
@@ -80,7 +81,7 @@ func TestEntProjectileTravelsThroughPortal(t *testing.T) {
 		t.Fatalf("destination spawn event position = %v, want %v", got, want)
 	}
 
-	<-nether.Exec(func(tx *world.Tx) {
+	mustDo(t, nether, func(tx *world.Tx) {
 		e, ok := handle.Entity(tx)
 		if !ok {
 			t.Fatal("entity was not added to the Nether")
@@ -122,15 +123,15 @@ func TestEntTravelsThroughPortalOnTick(t *testing.T) {
 	})
 
 	sourcePortal, targetPortal := cube.Pos{80, 64, 80}, cube.Pos{10, 64, 10}
-	<-overworld.Exec(func(tx *world.Tx) {
+	mustDo(t, overworld, func(tx *world.Tx) {
 		buildActivePortal(tx, sourcePortal)
 	})
-	<-nether.Exec(func(tx *world.Tx) {
+	mustDo(t, nether, func(tx *world.Tx) {
 		buildActivePortal(tx, targetPortal)
 	})
 
 	handle := world.EntitySpawnOpts{Position: sourcePortal.Vec3Middle().Sub(mgl64.Vec3{1})}.New(testMovingEntType{}, testMoveConfig{delta: mgl64.Vec3{1}})
-	<-overworld.Exec(func(tx *world.Tx) {
+	mustDo(t, overworld, func(tx *world.Tx) {
 		e := tx.AddEntity(handle)
 		ticker, ok := e.(world.TickerEntity)
 		if !ok {
@@ -143,7 +144,7 @@ func TestEntTravelsThroughPortalOnTick(t *testing.T) {
 	if entityInWorld(handle, overworld) {
 		t.Fatal("entity remained in the source world after tick-driven portal travel")
 	}
-	<-nether.Exec(func(tx *world.Tx) {
+	mustDo(t, nether, func(tx *world.Tx) {
 		e, ok := handle.Entity(tx)
 		if !ok {
 			t.Fatal("entity was not added to the Nether")
@@ -183,7 +184,7 @@ func TestPortalTravelComputerDelayedTravel(t *testing.T) {
 	_ = nether
 
 	tc := &PortalTravelComputer{}
-	<-overworld.Exec(func(tx *world.Tx) {
+	mustDo(t, overworld, func(tx *world.Tx) {
 		if destination := tc.enterPortal(tx, world.Nether); destination != nil {
 			t.Fatal("enterPortal() started travel before the portal timer finished")
 		}
@@ -204,7 +205,7 @@ func TestPortalTravelComputerCooldown(t *testing.T) {
 	_ = nether
 
 	tc := NewPortalTravelComputer()
-	<-overworld.Exec(func(tx *world.Tx) {
+	mustDo(t, overworld, func(tx *world.Tx) {
 		tc.cooldownUntil = time.Now().Add(time.Hour)
 		if destination := tc.enterPortal(tx, world.Nether); destination != nil {
 			t.Fatal("enterPortal() started travel during the portal cooldown")
@@ -226,7 +227,7 @@ func TestEntPortalTravelWithoutDestinationPortal(t *testing.T) {
 	sourcePos := mgl64.Vec3{80.5, 64, 80.5}
 	handle := world.EntitySpawnOpts{Position: sourcePos}.New(EnderPearlType, enderPearlConf)
 	var tc *PortalTravelComputer
-	<-overworld.Exec(func(tx *world.Tx) {
+	mustDo(t, overworld, func(tx *world.Tx) {
 		e := tx.AddEntity(handle)
 		tc = e.(*Ent).Behaviour().(*ProjectileBehaviour).PortalTravelComputer()
 		(block.Portal{Axis: cube.Z}).EntityInside(cube.PosFromVec3(sourcePos), tx, e)
@@ -253,13 +254,13 @@ func TestEntPortalTravelWithoutDestinationPortal(t *testing.T) {
 	if spawnRecorder.called {
 		t.Fatal("entity was spawned in the destination world without a linked portal")
 	}
-	<-overworld.Exec(func(tx *world.Tx) {
+	mustDo(t, overworld, func(tx *world.Tx) {
 		e, _ := handle.Entity(tx)
 		if got := e.Position(); !got.ApproxEqual(sourcePos) {
 			t.Fatalf("entity position after failed portal travel = %v, want %v", got, sourcePos)
 		}
 	})
-	<-nether.Exec(func(tx *world.Tx) {
+	mustDo(t, nether, func(tx *world.Tx) {
 		if _, ok := portal.FindNetherPortal(tx, cube.Pos{10, 64, 10}, 16); ok {
 			t.Fatal("a portal was created in the destination world by a non-player entity")
 		}
@@ -273,13 +274,13 @@ func TestFallingBlockDoesNotTravelThroughPortal(t *testing.T) {
 	nether.Handle(spawnRecorder)
 
 	targetPortal := cube.Pos{10, 64, 10}
-	<-nether.Exec(func(tx *world.Tx) {
+	mustDo(t, nether, func(tx *world.Tx) {
 		buildActivePortal(tx, targetPortal)
 	})
 
 	sourcePos := mgl64.Vec3{80.5, 64, 80.5}
 	handle := NewFallingBlock(world.EntitySpawnOpts{Position: sourcePos}, block.Sand{})
-	<-overworld.Exec(func(tx *world.Tx) {
+	mustDo(t, overworld, func(tx *world.Tx) {
 		e := tx.AddEntity(handle)
 		(block.Portal{Axis: cube.Z}).EntityInside(cube.PosFromVec3(sourcePos), tx, e)
 	})
@@ -299,13 +300,13 @@ func TestEntPortalTravelCreatesPortal(t *testing.T) {
 
 	sourcePos := mgl64.Vec3{80.5, 64, 80.5}
 	handle := world.EntitySpawnOpts{Position: sourcePos}.New(testMovingEntType{}, testPortalCreatorConfig{})
-	<-overworld.Exec(func(tx *world.Tx) {
+	mustDo(t, overworld, func(tx *world.Tx) {
 		e := tx.AddEntity(handle)
 		(block.Portal{Axis: cube.Z}).EntityInside(cube.PosFromVec3(sourcePos), tx, e)
 	})
 
 	waitForEntityWorld(t, handle, nether)
-	<-nether.Exec(func(tx *world.Tx) {
+	mustDo(t, nether, func(tx *world.Tx) {
 		if _, ok := portal.FindNetherPortal(tx, cube.Pos{10, 64, 10}, 16); !ok {
 			t.Fatal("no portal was created in the destination world for a portal-creating entity")
 		}
@@ -334,6 +335,13 @@ func portalWorlds(t *testing.T) (overworld, nether *world.World) {
 	return overworld, nether
 }
 
+func mustDo(t *testing.T, w *world.World, f func(tx *world.Tx)) {
+	t.Helper()
+	if err := w.Do(f).Wait(context.Background()); err != nil {
+		t.Fatalf("world task failed: %v", err)
+	}
+}
+
 // testPortalCreatorConfig configures a test entity that may create destination portals, like a player.
 type testPortalCreatorConfig struct{}
 
@@ -357,21 +365,12 @@ func waitForEntityWorld(t *testing.T, handle *world.EntityHandle, w *world.World
 }
 
 func entityInWorld(handle *world.EntityHandle, w *world.World) bool {
-	result := make(chan bool, 1)
-	go func() {
-		var ok bool
-		running := handle.ExecWorld(func(tx *world.Tx, _ world.Entity) {
-			ok = tx.World() == w
-		})
-		result <- running && ok
-	}()
-
-	select {
-	case ok := <-result:
-		return ok
-	case <-time.After(50 * time.Millisecond):
-		return false
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	inWorld, err := world.CallEntity(ctx, handle, func(tx *world.Tx, _ world.Entity) (bool, error) {
+		return tx.World() == w, nil
+	})
+	return err == nil && inWorld
 }
 
 func buildActivePortal(tx *world.Tx, origin cube.Pos) {

--- a/server/entity/travel_test.go
+++ b/server/entity/travel_test.go
@@ -267,6 +267,33 @@ func TestEntPortalTravelWithoutDestinationPortal(t *testing.T) {
 	})
 }
 
+func TestPortalTravelClosesHandleWhenBothWorldsClose(t *testing.T) {
+	source := world.Config{Synchronous: true}.New()
+	destination := world.Config{Dim: world.Nether, Synchronous: true}.New()
+
+	origin := mgl64.Vec3{80.5, 64, 80.5}
+	handle := world.EntitySpawnOpts{Position: origin}.New(EnderPearlType, enderPearlConf)
+	mustDo(t, source, func(tx *world.Tx) {
+		e := tx.AddEntity(handle)
+		if removed := tx.RemoveEntity(e); removed != handle {
+			t.Fatal("RemoveEntity() did not return the entity handle")
+		}
+	})
+	if err := destination.Close(); err != nil {
+		t.Fatalf("close destination world: %v", err)
+	}
+	if err := source.Close(); err != nil {
+		t.Fatalf("close source world: %v", err)
+	}
+
+	tc := NewPortalTravelComputer()
+	tc.transfer(handle, source, destination, origin, cube.Pos{10, 64, 10}, world.Overworld, world.Nether)
+
+	if !handle.Closed() {
+		t.Fatal("entity handle remained worldless after destination and recovery worlds closed")
+	}
+}
+
 func TestFallingBlockDoesNotTravelThroughPortal(t *testing.T) {
 	overworld, nether := portalWorlds(t)
 

--- a/server/entity/travel_test.go
+++ b/server/entity/travel_test.go
@@ -294,6 +294,34 @@ func TestPortalTravelClosesHandleWhenBothWorldsClose(t *testing.T) {
 	}
 }
 
+func TestPortalTravelRethrowsDestinationPanic(t *testing.T) {
+	source := world.Config{Synchronous: true}.New()
+	destination := world.Config{Dim: world.Nether, Synchronous: true}.New()
+	t.Cleanup(func() {
+		_ = source.Close()
+		_ = destination.Close()
+	})
+	destination.Handle(panicSpawnHandler{})
+
+	origin := mgl64.Vec3{80.5, 64, 80.5}
+	handle := world.EntitySpawnOpts{Position: origin}.New(testMovingEntType{}, testPortalCreatorConfig{})
+	mustDo(t, source, func(tx *world.Tx) {
+		e := tx.AddEntity(handle)
+		if removed := tx.RemoveEntity(e); removed != handle {
+			t.Fatal("RemoveEntity() did not return the entity handle")
+		}
+	})
+
+	defer func() {
+		if recovered := recover(); recovered != "spawn panic" {
+			t.Fatalf("transfer panic = %v, want spawn panic", recovered)
+		}
+	}()
+	tc := NewPortalTravelComputer()
+	tc.CreatePortal = true
+	tc.transfer(handle, source, destination, origin, cube.Pos{10, 64, 10}, world.Overworld, world.Nether)
+}
+
 func TestFallingBlockDoesNotTravelThroughPortal(t *testing.T) {
 	overworld, nether := portalWorlds(t)
 
@@ -422,6 +450,10 @@ type entitySpawnRecorder struct {
 	called bool
 	pos    mgl64.Vec3
 }
+
+type panicSpawnHandler struct{ world.NopHandler }
+
+func (panicSpawnHandler) HandleEntitySpawn(*world.Tx, world.Entity) { panic("spawn panic") }
 
 func (r *entitySpawnRecorder) HandleEntitySpawn(_ *world.Tx, e world.Entity) {
 	r.called = true

--- a/server/player/ref.go
+++ b/server/player/ref.go
@@ -25,7 +25,8 @@ func DoAfter(h *world.EntityHandle, delay time.Duration, f func(tx *world.Tx, p 
 }
 
 // Call runs f with the player identified by h on its current world owner and
-// waits for its typed result.
+// waits for its typed result. If f panics, Call re-panics with the original
+// value on the waiting goroutine.
 func Call[T any](ctx context.Context, h *world.EntityHandle, f func(tx *world.Tx, p *Player) (T, error)) (T, error) {
 	return world.CallRef(ctx, NewRef(h), f)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -146,7 +146,6 @@ func (srv *Server) Accept() iter.Seq[*player.Player] {
 				return !yield(p), nil
 			})
 			if err != nil {
-				world.RethrowPanic(err)
 				srv.pmu.Lock()
 				delete(srv.p, inc.p.handle.UUID())
 				srv.pmu.Unlock()
@@ -250,7 +249,6 @@ func (srv *Server) Players(tx *world.Tx) iter.Seq[*player.Player] {
 				return !yield(p), nil
 			})
 			if err != nil {
-				world.RethrowPanic(err)
 				continue
 			}
 			if ret {

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -412,7 +412,6 @@ func (s *Session) handlePackets() {
 			return s.handlePacket(pk, tx, c)
 		})
 		if err != nil {
-			world.RethrowPanic(err)
 			if sessionOwnerStopped(err) {
 				return
 			}

--- a/server/world/entity_ref.go
+++ b/server/world/entity_ref.go
@@ -43,9 +43,10 @@ func typed[T Entity](f func(tx *Tx, e T)) func(*Tx, Entity) error {
 }
 
 // CallRef runs f with the ref's entity on its current world owner and waits
-// for the typed result. Off-owner code only, like Call. A panic in f is
-// recovered and returned as a *PanicError matching ErrTaskPanicked; call
-// RethrowPanic to restore panic semantics.
+// for the typed result. Off-owner code only, like Call. If f panics, CallRef
+// re-panics with the original value on the waiting goroutine. Context
+// cancellation stops pending work, but CallRef waits for a callback that has
+// already started.
 func CallRef[T any, E Entity](ctx context.Context, ref EntityRef[E], f func(tx *Tx, e E) (T, error)) (T, error) {
 	var zero T
 	ctx, err := callContext(ctx)

--- a/server/world/portal/nether_test.go
+++ b/server/world/portal/nether_test.go
@@ -91,11 +91,11 @@ func TestNetherPortalFromPos(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := world.New()
+			w := world.Config{Synchronous: true}.New()
 			t.Cleanup(func() { _ = w.Close() })
 
 			origin := cube.Pos{8, 10, 8}
-			<-w.Exec(func(tx *world.Tx) {
+			mustDo(t, w, func(tx *world.Tx) {
 				tt.build(tx, origin)
 				p, ok := portal.NetherPortalFromPos(tx, origin.Add(tt.pos))
 				if ok != tt.ok {
@@ -120,11 +120,11 @@ func TestPortalModelHasNoCollisionBBox(t *testing.T) {
 func TestActivateNetherPortal(t *testing.T) {
 	for _, axis := range []cube.Axis{cube.Z, cube.X} {
 		t.Run(axis.String(), func(t *testing.T) {
-			w := world.New()
+			w := world.Config{Synchronous: true}.New()
 			t.Cleanup(func() { _ = w.Close() })
 
 			origin := cube.Pos{8, 10, 8}
-			<-w.Exec(func(tx *world.Tx) {
+			mustDo(t, w, func(tx *world.Tx) {
 				buildVerticalFrame(tx, origin, axis, 2, 3)
 				if !portal.ActivateNetherPortal(tx, origin) {
 					t.Fatal("ActivateNetherPortal() = false, want true")
@@ -147,11 +147,11 @@ func TestActivateNetherPortal(t *testing.T) {
 }
 
 func TestFireChargeActivatesNetherPortal(t *testing.T) {
-	w := world.New()
+	w := world.Config{Synchronous: true}.New()
 	t.Cleanup(func() { _ = w.Close() })
 
 	origin := cube.Pos{8, 10, 8}
-	<-w.Exec(func(tx *world.Tx) {
+	mustDo(t, w, func(tx *world.Tx) {
 		buildVerticalFrame(tx, origin, cube.Z, 2, 3)
 		ctx := &item.UseContext{}
 		if ok := (item.FireCharge{}).UseOnBlock(origin.Side(cube.FaceDown), cube.FaceUp, cube.Pos{}.Vec3(), tx, nil, ctx); !ok {
@@ -167,11 +167,11 @@ func TestFireChargeActivatesNetherPortal(t *testing.T) {
 }
 
 func TestActivatedPortalCleanupOnBrokenFrame(t *testing.T) {
-	w := world.New()
+	w := world.Config{Synchronous: true}.New()
 	t.Cleanup(func() { _ = w.Close() })
 
 	origin := cube.Pos{8, 10, 8}
-	<-w.Exec(func(tx *world.Tx) {
+	mustDo(t, w, func(tx *world.Tx) {
 		buildVerticalFrame(tx, origin, cube.Z, 2, 3)
 		if !portal.ActivateNetherPortal(tx, origin) {
 			t.Fatal("ActivateNetherPortal() = false, want true")
@@ -235,4 +235,11 @@ func widthOffset(axis cube.Axis, width int) cube.Pos {
 		return cube.Pos{width, 0, 0}
 	}
 	return cube.Pos{0, 0, width}
+}
+
+func mustDo(t *testing.T, w *world.World, f func(tx *world.Tx)) {
+	t.Helper()
+	if err := w.Do(f).Err(); err != nil {
+		t.Fatalf("world task failed: %v", err)
+	}
 }

--- a/server/world/task.go
+++ b/server/world/task.go
@@ -26,8 +26,9 @@ var (
 	ErrEntityType = errors.New("world: unexpected entity type")
 )
 
-// PanicError is the Task error for a callback that panicked. It matches
-// errors.Is(err, ErrTaskPanicked) and keeps the original panic value and stack.
+// PanicError is the Task error for a fire-and-forget callback that panicked. It
+// matches errors.Is(err, ErrTaskPanicked) and keeps the original panic value
+// and stack. Synchronous Call functions re-panic with Value automatically.
 type PanicError struct {
 	// Value is the recovered panic value.
 	Value any
@@ -43,10 +44,11 @@ func (e *PanicError) Error() string {
 // Unwrap returns ErrTaskPanicked so errors.Is works.
 func (e *PanicError) Unwrap() error { return ErrTaskPanicked }
 
-// RethrowPanic re-panics with the original panic value if err wraps a
-// *PanicError. The original goroutine's stack remains in PanicError.Stack and
-// is logged through the World's Logger when recovered. RethrowPanic does
-// nothing for any other error, including nil.
+// RethrowPanic re-panics with the original panic value if an error obtained
+// from a Task wraps a *PanicError. The original goroutine's stack remains in
+// PanicError.Stack and is logged through the World's Logger when recovered.
+// RethrowPanic does nothing for any other error, including nil. Call functions
+// invoke it automatically.
 func RethrowPanic(err error) {
 	if pe, ok := errors.AsType[*PanicError](err); ok {
 		panic(pe.Value)
@@ -74,19 +76,28 @@ func executeWithRecovery(w *World, f func() error) (err error) {
 	return f()
 }
 
-// awaitTask waits for a task to complete or the context to cancel, returning
-// the result stored by the callback through the result pointer.
+// awaitTask waits for a task to complete or for cancellation to stop a pending
+// task, returning the result stored by the callback through the result pointer.
+// Once a callback starts, awaitTask waits for it to finish so synchronous calls
+// preserve their result and panic semantics.
 func awaitTask[T any](ctx context.Context, task *Task, result *T) (T, error) {
 	var zero T
-	select {
-	case <-task.Done():
+	completed := func() (T, error) {
 		if err := task.Err(); err != nil {
+			RethrowPanic(err)
 			return zero, err
 		}
 		return *result, nil
+	}
+	select {
+	case <-task.Done():
+		return completed()
 	case <-ctx.Done():
-		task.Cancel()
-		return zero, ctx.Err()
+		if task.Cancel() {
+			return zero, ctx.Err()
+		}
+		<-task.Done()
+		return completed()
 	}
 }
 
@@ -307,9 +318,10 @@ func (w *World) DoAfter(delay time.Duration, f func(tx *Tx)) *Task {
 // Call runs f on w's owner and waits for its typed result. It is for
 // off-owner code such as tests, startup and background goroutines; if you
 // already have a *world.Tx, just use it directly. Calling it from the
-// owner itself (any scheduled callback or Handler event) deadlocks. A panic in
-// f is recovered and returned as a *PanicError matching ErrTaskPanicked; call
-// RethrowPanic to restore panic semantics.
+// owner itself (any scheduled callback or Handler event) deadlocks. If f
+// panics, Call re-panics with the original value on the waiting goroutine after
+// logging the original stack through the World's Logger. Context cancellation
+// stops pending work, but Call waits for a callback that has already started.
 func Call[T any](ctx context.Context, w *World, f func(tx *Tx) (T, error)) (T, error) {
 	var zero T
 	ctx, err := callContext(ctx)
@@ -326,9 +338,8 @@ func Call[T any](ctx context.Context, w *World, f func(tx *Tx) (T, error)) (T, e
 }
 
 // CallEntity runs f with the EntityHandle's entity on its current world owner
-// and waits for the typed result. Off-owner code only, like Call. A panic in f
-// is recovered and returned as a *PanicError matching ErrTaskPanicked; call
-// RethrowPanic to restore panic semantics.
+// and waits for the typed result. Off-owner code only, like Call. If f panics,
+// CallEntity re-panics with the original value on the waiting goroutine.
 func CallEntity[T any](ctx context.Context, h *EntityHandle, f func(tx *Tx, e Entity) (T, error)) (T, error) {
 	return CallRef(ctx, NewEntityRef[Entity](h), f)
 }

--- a/server/world/task.go
+++ b/server/world/task.go
@@ -44,12 +44,9 @@ func (e *PanicError) Error() string {
 // Unwrap returns ErrTaskPanicked so errors.Is works.
 func (e *PanicError) Unwrap() error { return ErrTaskPanicked }
 
-// RethrowPanic re-panics with the original panic value if an error obtained
-// from a Task wraps a *PanicError. The original goroutine's stack remains in
-// PanicError.Stack and is logged through the World's Logger when recovered.
-// RethrowPanic does nothing for any other error, including nil. Call functions
-// invoke it automatically.
-func RethrowPanic(err error) {
+// rethrowPanic re-panics with the original panic value if err wraps a
+// *PanicError. It does nothing for any other error, including nil.
+func rethrowPanic(err error) {
 	if pe, ok := errors.AsType[*PanicError](err); ok {
 		panic(pe.Value)
 	}
@@ -84,7 +81,7 @@ func awaitTask[T any](ctx context.Context, task *Task, result *T) (T, error) {
 	var zero T
 	completed := func() (T, error) {
 		if err := task.Err(); err != nil {
-			RethrowPanic(err)
+			rethrowPanic(err)
 			return zero, err
 		}
 		return *result, nil

--- a/server/world/task_test.go
+++ b/server/world/task_test.go
@@ -3,6 +3,8 @@ package world
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -10,6 +12,95 @@ import (
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/go-gl/mathgl/mgl64"
 )
+
+func TestCallRethrowsPanic(t *testing.T) {
+	w := Config{Log: slog.New(slog.NewTextHandler(io.Discard, nil))}.New()
+	t.Cleanup(func() { _ = w.Close() })
+
+	panicValue := &struct{ message string }{"call panic"}
+	defer func() {
+		if recovered := recover(); recovered != panicValue {
+			t.Fatalf("Call panic = %v, want original value %v", recovered, panicValue)
+		}
+	}()
+	_, _ = Call(context.Background(), w, func(*Tx) (struct{}, error) {
+		panic(panicValue)
+	})
+}
+
+func TestCallRefRethrowsPanic(t *testing.T) {
+	w := Config{Log: slog.New(slog.NewTextHandler(io.Discard, nil))}.New()
+	t.Cleanup(func() { _ = w.Close() })
+	h := NewEntity(taskTestEntityType{}, taskTestEntityConfig{})
+	if err := w.Do(func(tx *Tx) { tx.AddEntity(h) }).Wait(context.Background()); err != nil {
+		t.Fatalf("add entity: %v", err)
+	}
+
+	panicValue := &struct{ message string }{"call ref panic"}
+	defer func() {
+		if recovered := recover(); recovered != panicValue {
+			t.Fatalf("CallRef panic = %v, want original value %v", recovered, panicValue)
+		}
+	}()
+	_, _ = CallRef(context.Background(), NewEntityRef[Entity](h), func(*Tx, Entity) (struct{}, error) {
+		panic(panicValue)
+	})
+}
+
+func TestCallRethrowsPanicWhenCancellationLoses(t *testing.T) {
+	w := Config{Log: slog.New(slog.NewTextHandler(io.Discard, nil))}.New()
+	t.Cleanup(func() { _ = w.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	release := make(chan struct{})
+	panicValue := &struct{ message string }{"call panic after cancellation"}
+	type outcome struct {
+		panicValue any
+		err        error
+	}
+	result := make(chan outcome, 1)
+	go func() {
+		var out outcome
+		defer func() {
+			out.panicValue = recover()
+			result <- out
+		}()
+		_, out.err = Call(ctx, w, func(*Tx) (struct{}, error) {
+			close(started)
+			<-release
+			panic(panicValue)
+		})
+	}()
+
+	<-started
+	cancel()
+	select {
+	case out := <-result:
+		close(release)
+		t.Fatalf("Call returned before running callback completed: panic = %v, err = %v", out.panicValue, out.err)
+	case <-time.After(20 * time.Millisecond):
+		close(release)
+	}
+	out := <-result
+	if out.panicValue != panicValue {
+		t.Fatalf("Call panic = %v, want original value %v (err = %v)", out.panicValue, panicValue, out.err)
+	}
+}
+
+func TestDoCapturesPanic(t *testing.T) {
+	w := Config{Synchronous: true, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}.New()
+	t.Cleanup(func() { _ = w.Close() })
+
+	panicValue := &struct{ message string }{"do panic"}
+	task := w.Do(func(*Tx) { panic(panicValue) })
+	var panicErr *PanicError
+	if err := task.Err(); !errors.As(err, &panicErr) {
+		t.Fatalf("Do error = %v, want *PanicError", err)
+	}
+	if panicErr.Value != panicValue {
+		t.Fatalf("PanicError.Value = %v, want original value %v", panicErr.Value, panicValue)
+	}
+}
 
 func TestEntityDoCancelAfterInvalidatedWeakTransactionDoesNotPoisonHandle(t *testing.T) {
 	w := New()


### PR DESCRIPTION
## Summary

- migrate Nether portal tests and travel code from removed `World.Exec`/`EntityHandle.ExecWorld` APIs to owner-safe tasks
- defer queued portal removal on the existing source transaction and harden world-close recovery
- make synchronous `Call`, `CallRef`, `CallEntity`, and `player.Call` propagate callback panics automatically
- keep panic capture through `PanicError` for fire-and-forget `Do`, `DoAfter`, and `Defer` tasks

## Root cause

The owner-safe scheduling change removed the old blocking transaction APIs, but the recently merged Nether portal and portal-travel code still referenced them. The initial migration also exposed a synchronous API design issue: every production `Call*` consumer immediately reversed the default panic-as-error behavior.

## Scheduling semantics

Synchronous `Call*` functions now behave like ordinary function calls: a callback panic is logged with its original stack on the owner and re-panicked with the original value on the waiting goroutine. Context cancellation still cancels pending work; once a callback starts, the caller waits for its result or panic.

Fire-and-forget task APIs continue to capture callback panics as `*world.PanicError`, available through `Task.Err`, `Task.Wait`, and `Task.OnDone`. Panic rethrowing is an internal detail of synchronous calls rather than an additional exported API.

## Validation

- `go test ./...`
- `go test -race ./server/world ./server/entity ./server/world/portal`
- panic propagation tests repeated with `-count=20`
- `make lint`