### PR TITLE
Allow specifying private key for NetherNet listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # NetherNet server identity key
 identity.pem
+nethernet_identity.pem

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /world/
 /players/
 /resources/
+
+# NetherNet server identity key
+identity.pem

--- a/config.toml
+++ b/config.toml
@@ -4,12 +4,18 @@
   # server is already running on this port, please select a different port.
   Address = ":19132"
   # Transport controls which network transports are listened on. Valid values are raknet, nethernet and both.
-  Transport = "raknet"
+  Transport = "nethernet"
 
   [Network.NetherNet]
     # Address is the TCP address used for NetherNet HTTP signaling. If empty, Network.Address is used.
     # The listener serves plaintext HTTP. Terminate HTTPS with a reverse proxy such as Caddy or nginx.
     Address = ""
+    # KeyFile is the path to the PEM file containing the private key used to identify this listener
+    # when clients connect over plain HTTP. If the file does not exist, a new key is generated and
+    # saved there.
+    KeyFile = "identity.pem"
+    # Domain is the domain that may be displayed to players connecting over plain HTTP.
+    Domain = "self"
 
 [Server]
   # The name as it shows up in the server list. Minecraft colour codes may be used in this name to format the

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@
   # server is already running on this port, please select a different port.
   Address = ":19132"
   # Transport controls which network transports are listened on. Valid values are raknet, nethernet and both.
-  Transport = "nethernet"
+  Transport = "raknet"
 
   [Network.NetherNet]
     # Address is the TCP address used for NetherNet HTTP signaling. If empty, Network.Address is used.

--- a/config.toml
+++ b/config.toml
@@ -10,10 +10,10 @@
     # Address is the TCP address used for NetherNet HTTP signaling. If empty, Network.Address is used.
     # The listener serves plaintext HTTP. Terminate HTTPS with a reverse proxy such as Caddy or nginx.
     Address = ""
-    # KeyFile is the path to the PEM file containing the private key used to identify this listener
-    # when clients connect over plain HTTP. If the file does not exist, a new key is generated and
-    # saved there.
-    KeyFile = "identity.pem"
+    # KeyFile is the path to the PEM file containing the P-384 ECDSA private key used to identify
+    # this listener when clients connect over plain HTTP. If the file does not exist, a new key is
+    # generated and saved there. If empty, a temporary key is generated and not saved.
+    KeyFile = "nethernet_identity.pem"
     # Domain is the domain that may be displayed to players connecting over plain HTTP.
     Domain = "self"
 

--- a/server/conf.go
+++ b/server/conf.go
@@ -226,6 +226,12 @@ type UserConfig struct {
 			// Network.Address is used. The listener serves plaintext HTTP; HTTPS
 			// should be terminated by a reverse proxy.
 			Address string
+			// KeyFile is the path to the PEM file containing the private key used to identify this listener
+			// when clients connect over plain HTTP. If the file does not exist, a new key is generated and
+			// saved there.
+			KeyFile string
+			// Domain is the domain that may be displayed to players connecting over plain HTTP.
+			Domain string
 		}
 	}
 	Server struct {
@@ -384,6 +390,7 @@ func DefaultConfig() UserConfig {
 	c := UserConfig{}
 	c.Network.Address = ":19132"
 	c.Network.Transport = "raknet"
+	c.Network.NetherNet.KeyFile, c.Network.NetherNet.Domain = "identity.pem", "self"
 	c.Server.Name = "Dragonfly Server"
 	c.Server.AuthEnabled = true
 	c.World.SaveData = true

--- a/server/conf.go
+++ b/server/conf.go
@@ -226,9 +226,10 @@ type UserConfig struct {
 			// Network.Address is used. The listener serves plaintext HTTP; HTTPS
 			// should be terminated by a reverse proxy.
 			Address string
-			// KeyFile is the path to the PEM file containing the private key used to identify this listener
-			// when clients connect over plain HTTP. If the file does not exist, a new key is generated and
-			// saved there.
+			// KeyFile is the path to the PEM file containing the P-384 ECDSA private
+			// key used to identify this listener when clients connect over plain HTTP.
+			// If the file does not exist, a new key is generated and saved there. If
+			// empty, a temporary key is generated and not saved.
 			KeyFile string
 			// Domain is the domain that may be displayed to players connecting over plain HTTP.
 			Domain string
@@ -390,7 +391,7 @@ func DefaultConfig() UserConfig {
 	c := UserConfig{}
 	c.Network.Address = ":19132"
 	c.Network.Transport = "raknet"
-	c.Network.NetherNet.KeyFile, c.Network.NetherNet.Domain = "identity.pem", "self"
+	c.Network.NetherNet.KeyFile, c.Network.NetherNet.Domain = "nethernet_identity.pem", "self"
 	c.Server.Name = "Dragonfly Server"
 	c.Server.AuthEnabled = true
 	c.World.SaveData = true

--- a/server/listener.go
+++ b/server/listener.go
@@ -2,12 +2,18 @@ package server
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/df-mc/dragonfly/server/session"
@@ -39,12 +45,92 @@ func (uc UserConfig) listenerFunc(conf Config) (Listener, error) {
 	return listener{Listener: l}, nil
 }
 
+// importPrivateKey reads an PEM file containing an [ecdsa.PrivateKey] and returns
+// it for use by the NetherNet listener.
+func importPrivateKey(path string) (*ecdsa.PrivateKey, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err // already wrapped in os.PathError
+	}
+	block, _ := pem.Decode(b)
+	if block == nil {
+		return nil, errors.New("invalid PEM block")
+	}
+	switch block.Type {
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(block.Bytes)
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse private key: %w", err)
+		}
+		k, ok := key.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("must be *ecdsa.PrivateKey: %T", key)
+		}
+		return k, nil
+	default:
+		return nil, fmt.Errorf("invalid block type: %s", block.Type)
+	}
+}
+
+// exportPrivateKey writes an PEM file containing the [ecdsa.PrivateKey].
+func exportPrivateKey(path string, key *ecdsa.PrivateKey) error {
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return fmt.Errorf("encode: %w", err)
+	}
+	return os.WriteFile(path, pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: keyBytes,
+	}), 0644)
+}
+
 func (uc UserConfig) netherNetListenerFunc(conf Config) (Listener, error) {
 	nnConf := uc.Network.NetherNet
 	address := nnConf.Address
 	if address == "" {
 		address = uc.Network.Address
 	}
+	if nnConf.Domain == "" {
+		nnConf.Domain = "self"
+	}
+
+	lcfg := nethernet.ListenConfig{
+		Log:            conf.Log.With("net origin", "nethernet"),
+		AllowAnonymous: conf.AuthDisabled,
+	}
+	var key *ecdsa.PrivateKey
+	if nnConf.KeyFile != "" {
+		var err error
+		key, err = importPrivateKey(nnConf.KeyFile)
+		if os.IsNotExist(err) {
+			key, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+			if err != nil {
+				return nil, fmt.Errorf("generate key: %w", err)
+			}
+			// If we generated a new key for the NetherNet listener, save it.
+			// Otherwise, players may be prompted to trust the server identity
+			// after every restart.
+			if err := exportPrivateKey(nnConf.KeyFile, key); err != nil {
+				return nil, fmt.Errorf("export private key: %w", err)
+			}
+			lcfg.Log.Info("Generated a private key for NetherNet listener.", "path", nnConf.KeyFile)
+		} else if err != nil {
+			return nil, fmt.Errorf("import key file: %w", err)
+		}
+	} else {
+		var err error
+		key, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("generate key: %w", err)
+		}
+		lcfg.Log.Warn("Using a temporary private key for the NetherNet listener. Players connecting over plain HTTP may see the TOFU (Trust On First Use) prompt every time the server restarts.")
+	}
+	lcfg.IssueServerIdentity = func(ctx context.Context) (*nethernet.Identity, error) {
+		return nethernet.GenerateServerIdentity(key, nnConf.Domain)
+	}
+
 	tcp, err := net.Listen("tcp", address)
 	if err != nil {
 		return nil, fmt.Errorf("listen NetherNet HTTP: %w", err)
@@ -53,12 +139,8 @@ func (uc UserConfig) netherNetListenerFunc(conf Config) (Listener, error) {
 	handler := endpoint.HandlerConfig{Logger: log}.New()
 	cfg := listenerConfig(conf)
 	l, err := cfg.ListenNetwork(minecraft.NetherNet{
-		Signaling: handler,
-		ListenConfig: nethernet.ListenConfig{
-			Log:               conf.Log.With("net origin", "nethernet"),
-			AllowAnonymous:    conf.AuthDisabled,
-			DisableTrickleICE: true,
-		},
+		Signaling:    handler,
+		ListenConfig: lcfg,
 	}, handler.NetworkID())
 	if err != nil {
 		_ = tcp.Close()

--- a/server/listener.go
+++ b/server/listener.go
@@ -45,8 +45,8 @@ func (uc UserConfig) listenerFunc(conf Config) (Listener, error) {
 	return listener{Listener: l}, nil
 }
 
-// importPrivateKey reads an PEM file containing an [ecdsa.PrivateKey] and returns
-// it for use by the NetherNet listener.
+// importPrivateKey reads a PEM file containing a P-384 [ecdsa.PrivateKey] and
+// returns it for use by the NetherNet listener.
 func importPrivateKey(path string) (*ecdsa.PrivateKey, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
@@ -56,34 +56,57 @@ func importPrivateKey(path string) (*ecdsa.PrivateKey, error) {
 	if block == nil {
 		return nil, errors.New("invalid PEM block")
 	}
+	var key *ecdsa.PrivateKey
 	switch block.Type {
 	case "EC PRIVATE KEY":
-		return x509.ParseECPrivateKey(block.Bytes)
+		key, err = x509.ParseECPrivateKey(block.Bytes)
 	case "PRIVATE KEY":
-		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		var parsed any
+		parsed, err = x509.ParsePKCS8PrivateKey(block.Bytes)
 		if err != nil {
 			return nil, fmt.Errorf("parse private key: %w", err)
 		}
-		k, ok := key.(*ecdsa.PrivateKey)
+		var ok bool
+		key, ok = parsed.(*ecdsa.PrivateKey)
 		if !ok {
-			return nil, fmt.Errorf("must be *ecdsa.PrivateKey: %T", key)
+			return nil, fmt.Errorf("must be *ecdsa.PrivateKey: %T", parsed)
 		}
-		return k, nil
 	default:
 		return nil, fmt.Errorf("invalid block type: %s", block.Type)
 	}
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+	if key.Curve != elliptic.P384() {
+		return nil, fmt.Errorf("private key must use P-384, got %s", key.Curve.Params().Name)
+	}
+	return key, nil
 }
 
-// exportPrivateKey writes an PEM file containing the [ecdsa.PrivateKey].
+// exportPrivateKey writes a PEM file containing the [ecdsa.PrivateKey].
 func exportPrivateKey(path string, key *ecdsa.PrivateKey) error {
 	keyBytes, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
 		return fmt.Errorf("encode: %w", err)
 	}
-	return os.WriteFile(path, pem.EncodeToMemory(&pem.Block{
+	b := pem.EncodeToMemory(&pem.Block{
 		Type:  "EC PRIVATE KEY",
 		Bytes: keyBytes,
-	}), 0644)
+	})
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(b); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("write: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("close: %w", err)
+	}
+	return nil
 }
 
 func (uc UserConfig) netherNetListenerFunc(conf Config) (Listener, error) {


### PR DESCRIPTION
In future versions (probably .40), clients will allow connecting to plain HTTP servers, but will prompt players to decide whether to trust the server's public key. That key is also used to sign the WebRTC connection's fingerprint (even when connecting to HTTPS server), which is required to secure the connection because Minecraft does not enable encryption even after the S2C/C2S handshake packets have been exchanged.

<img height="362" alt="image" src="https://github.com/user-attachments/assets/a3bc1407-04e0-4ea7-8d5e-54f16cadc823" />

currently `go-nethernet` generates that key randomly, which means players may see that prompt every time the server restarts.

This PR adds a config field specifying the file path where the private key is stored.

