### PR TITLE
feat(dimensions): allow custom dimension registry

### DIFF
--- a/server/player/playerdb/json.go
+++ b/server/player/playerdb/json.go
@@ -92,7 +92,7 @@ func (p *Provider) toJson(d player.Config, w *world.World) jsonData {
 			MainHandSlot: uint32(d.HeldSlot),
 		}),
 		EnderChestInventory: encodeItems(d.EnderChestInventory.Slots()),
-		Dimension:           uint8(dim),
+		Dimension:           int32(dim),
 	}
 }
 
@@ -115,7 +115,7 @@ type jsonData struct {
 	Effects                          []jsonEffect
 	FireTicks                        int64
 	FallDistance                     float64
-	Dimension                        uint8
+	Dimension                        int32
 }
 
 type jsonInventoryData struct {

--- a/server/server.go
+++ b/server/server.go
@@ -47,8 +47,9 @@ type Server struct {
 
 	world, nether, end *world.World
 
-	customBlocks []protocol.BlockEntry
-	customItems  []protocol.ItemEntry
+	customBlocks     []protocol.BlockEntry
+	customItems      []protocol.ItemEntry
+	customDimensions []protocol.DimensionDefinition
 
 	listeners []Listener
 	incoming  chan incoming
@@ -387,6 +388,7 @@ func (srv *Server) listen(l Listener) {
 func (srv *Server) startListening() {
 	srv.makeBlockEntries()
 	srv.makeItemComponents()
+	srv.makeDimensionData()
 
 	srv.wg.Add(len(srv.listeners))
 	for _, l := range srv.listeners {
@@ -431,6 +433,21 @@ func (srv *Server) makeItemComponents() {
 			RuntimeID:      int16(rid),
 			Version:        entryVersion,
 			Data:           iteminternal.Components(it),
+		})
+	}
+}
+
+// makeDimensionData initialises the server's custom dimensions list.
+func (srv *Server) makeDimensionData() {
+	dimensions := world.CustomDimensions()
+	srv.customDimensions = make([]protocol.DimensionDefinition, 0, len(dimensions))
+	for _, registration := range dimensions {
+		r := registration.Dimension.Range()
+		srv.customDimensions = append(srv.customDimensions, protocol.DimensionDefinition{
+			Name:          registration.Name,
+			Range:         [2]int32{int32(r.Min()), int32(r.Max())},
+			Generator:     protocol.GeneratorVoid,
+			DimensionType: int32(registration.ID),
 		})
 	}
 }
@@ -509,6 +526,7 @@ func (srv *Server) defaultGameData() minecraft.GameData {
 		PlayerMovementSettings: protocol.PlayerMovementSettings{
 			ServerAuthoritativeBlockBreaking: true,
 		},
+		Dimensions: srv.customDimensions,
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -445,7 +445,7 @@ func (srv *Server) makeDimensionData() {
 		r := registration.Dimension.Range()
 		srv.customDimensions = append(srv.customDimensions, protocol.DimensionDefinition{
 			Name:          registration.Name,
-			Range:         [2]int32{int32(r.Min()), int32(r.Max())},
+			Range:         [2]int32{int32(r.Max() + 1), int32(r.Min())},
 			Generator:     protocol.GeneratorVoid,
 			DimensionType: int32(registration.ID),
 		})

--- a/server/world/dimension.go
+++ b/server/world/dimension.go
@@ -1,8 +1,12 @@
 package world
 
 import (
-	"github.com/df-mc/dragonfly/server/block/cube"
+	"fmt"
+	"math"
+	"slices"
 	"time"
+
+	"github.com/df-mc/dragonfly/server/block/cube"
 )
 
 var (
@@ -40,6 +44,14 @@ func DimensionID(dim Dimension) (int, bool) {
 type dimensionRegistry struct {
 	dimensions map[int]Dimension
 	ids        map[Dimension]int
+	custom     []DimensionRegistration
+}
+
+// DimensionRegistration holds a custom dimension's registration data.
+type DimensionRegistration struct {
+	ID        int
+	Name      string
+	Dimension Dimension
 }
 
 // newDimensionRegistry returns an initialised dimensionRegistry.
@@ -67,6 +79,39 @@ func (reg *dimensionRegistry) Lookup(id int) (Dimension, bool) {
 func (reg *dimensionRegistry) LookupID(dim Dimension) (int, bool) {
 	id, ok := reg.ids[dim]
 	return id, ok
+}
+
+// RegisterDimension registers a custom dimension.
+func (reg *dimensionRegistry) RegisterDimension(id int, name string, dim Dimension) error {
+	if id < 1000 || id > math.MaxInt32 {
+		return fmt.Errorf("custom dimension ID must be between 1000 and %d", math.MaxInt32)
+	}
+	if name == "" {
+		return fmt.Errorf("custom dimension name must not be empty")
+	}
+	if dim == nil {
+		return fmt.Errorf("custom dimension must not be nil")
+	}
+	if _, ok := reg.dimensions[id]; ok {
+		return fmt.Errorf("dimension ID %d is already registered", id)
+	}
+	if existing, ok := reg.ids[dim]; ok {
+		return fmt.Errorf("dimension is already registered with ID %d", existing)
+	}
+	reg.dimensions[id] = dim
+	reg.ids[dim] = id
+	reg.custom = append(reg.custom, DimensionRegistration{ID: id, Name: name, Dimension: dim})
+	return nil
+}
+
+// RegisterDimension registers a custom dimension.
+func RegisterDimension(id int, name string, dim Dimension) error {
+	return dimensionReg.RegisterDimension(id, name, dim)
+}
+
+// CustomDimensions returns all registered custom dimensions.
+func CustomDimensions() []DimensionRegistration {
+	return slices.Clone(dimensionReg.custom)
 }
 
 type (

--- a/server/world/dimension.go
+++ b/server/world/dimension.go
@@ -83,8 +83,8 @@ func (reg *dimensionRegistry) LookupID(dim Dimension) (int, bool) {
 
 // RegisterDimension registers a custom dimension.
 func (reg *dimensionRegistry) RegisterDimension(id int, name string, dim Dimension) error {
-	if id < 1000 || id > math.MaxInt32 {
-		return fmt.Errorf("custom dimension ID must be between 1000 and %d", math.MaxInt32)
+	if id < 1000 || id > math.MaxUint16 {
+		return fmt.Errorf("custom dimension ID must be between 1000 and %d", math.MaxUint16)
 	}
 	if name == "" {
 		return fmt.Errorf("custom dimension name must not be empty")
@@ -92,11 +92,26 @@ func (reg *dimensionRegistry) RegisterDimension(id int, name string, dim Dimensi
 	if dim == nil {
 		return fmt.Errorf("custom dimension must not be nil")
 	}
+	r := dim.Range()
+	if r.Min() > r.Max() {
+		return fmt.Errorf("custom dimension range must not be empty")
+	}
+	if r.Min()%16 != 0 || (r.Max()+1)%16 != 0 {
+		return fmt.Errorf("custom dimension range must align with 16-block sub-chunks")
+	}
+	if r.Min() < math.MinInt16 || r.Max() > math.MaxInt16 {
+		return fmt.Errorf("custom dimension range must be between %d and %d", math.MinInt16, math.MaxInt16)
+	}
 	if _, ok := reg.dimensions[id]; ok {
 		return fmt.Errorf("dimension ID %d is already registered", id)
 	}
 	if existing, ok := reg.ids[dim]; ok {
 		return fmt.Errorf("dimension is already registered with ID %d", existing)
+	}
+	for _, existing := range reg.custom {
+		if existing.Name == name {
+			return fmt.Errorf("dimension name %q is already registered", name)
+		}
 	}
 	reg.dimensions[id] = dim
 	reg.ids[dim] = id


### PR DESCRIPTION
## Summary
- advertise registered custom dimensions to clients with correct minimum and maximum bounds
- accept explicit stable IDs from 1000 and reject duplicate IDs or dimensions
- preserve custom dimension IDs through the default player provider
- keep the exported `world.Dimension` interface backward-compatible

## Sources
- https://github.com/Mojang/bedrock-protocol-docs/blob/main/json/DimensionType.json
- https://github.com/Mojang/bedrock-protocol-docs/blob/main/json/DimensionDefinition.json
- https://github.com/Mojang/bedrock-protocol-docs/blob/main/json/DimensionDataPacketPayload.json

## Testing
- `go test ./...`