### PR TITLE
server/block: Fix outdated custom block components

### DIFF
--- a/server/internal/blockinternal/components.go
+++ b/server/internal/blockinternal/components.go
@@ -14,7 +14,7 @@ func Components(identifier string, b world.CustomBlock, blockID int32) map[strin
 	builder := NewComponentBuilder(identifier, components, blockID)
 	if emitter, ok := b.(block.LightEmitter); ok {
 		builder.AddComponent("minecraft:light_emission", map[string]any{
-			"emission": emitter.LightEmissionLevel(),
+			"emission": int32(emitter.LightEmissionLevel()),
 		})
 	}
 	if diffuser, ok := b.(block.LightDiffuser); ok {

--- a/server/internal/blockinternal/components.go
+++ b/server/internal/blockinternal/components.go
@@ -13,12 +13,12 @@ func Components(identifier string, b world.CustomBlock, blockID int32) map[strin
 	components := componentsFromProperties(b.Properties())
 	builder := NewComponentBuilder(identifier, components, blockID)
 	if emitter, ok := b.(block.LightEmitter); ok {
-		builder.AddComponent("minecraft:block_light_emission", map[string]any{
-			"emission": float32(emitter.LightEmissionLevel() / 15),
+		builder.AddComponent("minecraft:light_emission", map[string]any{
+			"emission": emitter.LightEmissionLevel(),
 		})
 	}
 	if diffuser, ok := b.(block.LightDiffuser); ok {
-		builder.AddComponent("minecraft:block_light_filter", map[string]any{
+		builder.AddComponent("minecraft:light_dampening", map[string]any{
 			"lightLevel": int32(diffuser.LightDiffusionLevel()),
 		})
 	}
@@ -63,7 +63,7 @@ func componentsFromProperties(props customblock.Properties) map[string]any {
 	if props.Geometry != "" {
 		components["minecraft:geometry"] = map[string]any{"identifier": props.Geometry}
 	} else if props.Cube {
-		components["minecraft:unit_cube"] = map[string]any{}
+		components["minecraft:geometry"] = map[string]any{"identifier": "minecraft:geometry.full_block"}
 	}
 	if props.MapColour != "" {
 		components["minecraft:map_color"] = map[string]any{"value": props.MapColour}


### PR DESCRIPTION
Dragonfly still sends custom blocks using components that are deprecated in current Bedrock versions. As a result, full-cube custom blocks may not render correctly, and their light properties may not be applied by the client.

Update the generated components to their modern equivalents:

- Replace [`minecraft:block_light_filter`](https://wiki.bedrock.dev/blocks/block-format-history#_1-19-10) with `minecraft:light_dampening`.
- Replace [`minecraft:block_light_emission`](https://wiki.bedrock.dev/blocks/block-format-history#_1-19-20) with `minecraft:light_emission` and encode the `0-15` value returned by `LightEmissionLevel()` as an NBT integer.
- Replace [`minecraft:unit_cube`](https://wiki.bedrock.dev/blocks/block-format-history#_1-20-60) with `minecraft:geometry` using the `minecraft:geometry.full_block` identifier.

These changes only affect the internal block components sent to the client. The public custom-block API remains unchanged.