### PR TITLE
cube/bbox.go: support float32 bounding boxes

### DIFF
--- a/server/block/cube/bbox.go
+++ b/server/block/cube/bbox.go
@@ -5,14 +5,17 @@ import (
 	"github.com/go-gl/mathgl/mgl64"
 )
 
+// number represents a floating-point number supported by a bounding box.
 type number interface {
 	~float32 | ~float64
 }
 
+// vec3 represents a three-dimensional vector of floating-point numbers.
 type vec3[T number] interface {
 	~[3]T
 }
 
+// boundingBox represents an axis-aligned bounding box backed by a vector type.
 type boundingBox[T number, V vec3[T]] struct {
 	min, max V
 }

--- a/server/block/cube/bbox.go
+++ b/server/block/cube/bbox.go
@@ -1,19 +1,45 @@
 package cube
 
 import (
+	"github.com/go-gl/mathgl/mgl32"
 	"github.com/go-gl/mathgl/mgl64"
 )
 
+type number interface {
+	~float32 | ~float64
+}
+
+type vec3[T number] interface {
+	~[3]T
+}
+
+type boundingBox[T number, V vec3[T]] struct {
+	min, max V
+}
+
 // BBox represents an Axis Aligned Bounding Box in a 3D space. It is defined as
 // two Vec3s, of which one is the minimum and one is the maximum.
-type BBox struct {
-	min, max mgl64.Vec3
-}
+type BBox = boundingBox[float64, mgl64.Vec3]
+
+// BBox32 represents a float32 Axis Aligned Bounding Box in a 3D space. It is
+// defined as two Vec3s, of which one is the minimum and one is the maximum.
+type BBox32 = boundingBox[float32, mgl32.Vec3]
 
 // Box creates a new axis aligned bounding box with the minimum and maximum
 // coordinates provided. The returned box has minimum and maximum coordinates
 // swapped if necessary so that it is well-formed.
 func Box(x0, y0, z0, x1, y1, z1 float64) BBox {
+	return newBox[float64, mgl64.Vec3](x0, y0, z0, x1, y1, z1)
+}
+
+// Box32 creates a new float32 axis aligned bounding box with the minimum and
+// maximum coordinates provided. The returned box has minimum and maximum
+// coordinates swapped if necessary so that it is well-formed.
+func Box32(x0, y0, z0, x1, y1, z1 float32) BBox32 {
+	return newBox[float32, mgl32.Vec3](x0, y0, z0, x1, y1, z1)
+}
+
+func newBox[T number, V vec3[T]](x0, y0, z0, x1, y1, z1 T) boundingBox[T, V] {
 	if x0 > x1 {
 		x0, x1 = x1, x0
 	}
@@ -23,72 +49,67 @@ func Box(x0, y0, z0, x1, y1, z1 float64) BBox {
 	if z0 > z1 {
 		z0, z1 = z1, z0
 	}
-	return BBox{min: mgl64.Vec3{x0, y0, z0}, max: mgl64.Vec3{x1, y1, z1}}
+	return boundingBox[T, V]{min: V{x0, y0, z0}, max: V{x1, y1, z1}}
 }
 
 // Grow grows the bounding box in all directions by x and returns the new
 // bounding box.
-func (box BBox) Grow(x float64) BBox {
-	add := mgl64.Vec3{x, x, x}
-	return BBox{min: box.min.Sub(add), max: box.max.Add(add)}
+func (box boundingBox[T, V]) Grow(x T) boundingBox[T, V] {
+	return box.GrowVec3(V{x, x, x})
 }
 
 // GrowVec3 grows the BBox on all axes as represented by the Vec3 passed. The
 // vec values are subtracted from the minimum values of the BBox and added to
 // the maximum values of the BBox.
-func (box BBox) GrowVec3(vec mgl64.Vec3) BBox {
-	return BBox{min: box.min.Sub(vec), max: box.max.Add(vec)}
+func (box boundingBox[T, V]) GrowVec3(vec V) boundingBox[T, V] {
+	for i := range 3 {
+		box.min[i] -= vec[i]
+		box.max[i] += vec[i]
+	}
+	return box
 }
 
 // Min returns the minimum coordinate of the bounding box.
-func (box BBox) Min() mgl64.Vec3 {
+func (box boundingBox[T, V]) Min() V {
 	return box.min
 }
 
 // Max returns the maximum coordinate of the bounding box.
-func (box BBox) Max() mgl64.Vec3 {
+func (box boundingBox[T, V]) Max() V {
 	return box.max
 }
 
 // Width returns the width of the BBox.
-func (box BBox) Width() float64 {
+func (box boundingBox[T, V]) Width() T {
 	return box.max[0] - box.min[0]
 }
 
 // Length returns the length of the BBox.
-func (box BBox) Length() float64 {
+func (box boundingBox[T, V]) Length() T {
 	return box.max[2] - box.min[2]
 }
 
 // Height returns the height of the BBox.
-func (box BBox) Height() float64 {
+func (box boundingBox[T, V]) Height() T {
 	return box.max[1] - box.min[1]
 }
 
 // Extend expands the BBox on all axes as represented by the Vec3 passed.
 // Negative coordinates result in an expansion towards the negative axis, and
 // vice versa for positive coordinates.
-func (box BBox) Extend(vec mgl64.Vec3) BBox {
-	if vec[0] < 0 {
-		box.min[0] += vec[0]
-	} else if vec[0] > 0 {
-		box.max[0] += vec[0]
-	}
-	if vec[1] < 0 {
-		box.min[1] += vec[1]
-	} else if vec[1] > 0 {
-		box.max[1] += vec[1]
-	}
-	if vec[2] < 0 {
-		box.min[2] += vec[2]
-	} else if vec[2] > 0 {
-		box.max[2] += vec[2]
+func (box boundingBox[T, V]) Extend(vec V) boundingBox[T, V] {
+	for i := range 3 {
+		if vec[i] < 0 {
+			box.min[i] += vec[i]
+		} else if vec[i] > 0 {
+			box.max[i] += vec[i]
+		}
 	}
 	return box
 }
 
 // ExtendTowards extends the bounding box by x in a given direction.
-func (box BBox) ExtendTowards(f Face, x float64) BBox {
+func (box boundingBox[T, V]) ExtendTowards(f Face, x T) boundingBox[T, V] {
 	switch f {
 	case FaceDown:
 		box.min[1] -= x
@@ -107,7 +128,7 @@ func (box BBox) ExtendTowards(f Face, x float64) BBox {
 }
 
 // Stretch stretches the bounding box by x in a given axis.
-func (box BBox) Stretch(a Axis, x float64) BBox {
+func (box boundingBox[T, V]) Stretch(a Axis, x T) boundingBox[T, V] {
 	switch a {
 	case Y:
 		box.min[1] -= x
@@ -124,37 +145,44 @@ func (box BBox) Stretch(a Axis, x float64) BBox {
 
 // Translate moves the entire BBox with the Vec3 given. The (minimum and
 // maximum) x, y and z coordinates are moved by those in the Vec3 passed.
-func (box BBox) Translate(vec mgl64.Vec3) BBox {
-	return BBox{min: box.min.Add(vec), max: box.max.Add(vec)}
-}
-
-// TranslateTowards moves the entire BBox by x in the direction of a Face f.
-func (box BBox) TranslateTowards(f Face, x float64) BBox {
-	switch f {
-	case FaceDown:
-		return box.Translate(mgl64.Vec3{0, -x, 0})
-	case FaceUp:
-		return box.Translate(mgl64.Vec3{0, x, 0})
-	case FaceNorth:
-		return box.Translate(mgl64.Vec3{0, 0, -x})
-	case FaceSouth:
-		return box.Translate(mgl64.Vec3{0, 0, x})
-	case FaceWest:
-		return box.Translate(mgl64.Vec3{-x, 0, 0})
-	case FaceEast:
-		return box.Translate(mgl64.Vec3{x, 0, 0})
+func (box boundingBox[T, V]) Translate(vec V) boundingBox[T, V] {
+	for i := range 3 {
+		box.min[i] += vec[i]
+		box.max[i] += vec[i]
 	}
 	return box
 }
 
+// TranslateTowards moves the entire BBox by x in the direction of a Face f.
+func (box boundingBox[T, V]) TranslateTowards(f Face, x T) boundingBox[T, V] {
+	var vec V
+	switch f {
+	case FaceDown:
+		vec[1] = -x
+	case FaceUp:
+		vec[1] = x
+	case FaceNorth:
+		vec[2] = -x
+	case FaceSouth:
+		vec[2] = x
+	case FaceWest:
+		vec[0] = -x
+	case FaceEast:
+		vec[0] = x
+	default:
+		return box
+	}
+	return box.Translate(vec)
+}
+
 // IntersectsWith checks if the BBox intersects with another BBox.
-func (box BBox) IntersectsWith(other BBox) bool {
+func (box boundingBox[T, V]) IntersectsWith(other boundingBox[T, V]) bool {
 	return box.intersectsWith(other, 1e-5)
 }
 
 // intersectsWith checks if the BBox intersects with another BBox using a
 // specific epsilon.
-func (box BBox) intersectsWith(other BBox, epsilon float64) bool {
+func (box boundingBox[T, V]) intersectsWith(other boundingBox[T, V], epsilon T) bool {
 	if other.max[0]-box.min[0] > epsilon && box.max[0]-other.min[0] > epsilon {
 		if other.max[1]-box.min[1] > epsilon && box.max[1]-other.min[1] > epsilon {
 			return other.max[2]-box.min[2] > epsilon && box.max[2]-other.min[2] > epsilon
@@ -165,6 +193,15 @@ func (box BBox) intersectsWith(other BBox, epsilon float64) bool {
 
 // AnyIntersections checks if any of boxes intersect with search.
 func AnyIntersections(boxes []BBox, search BBox) bool {
+	return anyIntersections(boxes, search)
+}
+
+// AnyIntersections32 checks if any of the float32 boxes intersect with search.
+func AnyIntersections32(boxes []BBox32, search BBox32) bool {
+	return anyIntersections(boxes, search)
+}
+
+func anyIntersections[T number, V vec3[T]](boxes []boundingBox[T, V], search boundingBox[T, V]) bool {
 	for _, box := range boxes {
 		if box.intersectsWith(search, 0) {
 			return true
@@ -174,7 +211,7 @@ func AnyIntersections(boxes []BBox, search BBox) bool {
 }
 
 // Vec3Within checks if a BBox has vec within it.
-func (box BBox) Vec3Within(vec mgl64.Vec3) bool {
+func (box boundingBox[T, V]) Vec3Within(vec V) bool {
 	if vec[0] <= box.min[0] || vec[0] >= box.max[0] {
 		return false
 	}
@@ -185,7 +222,7 @@ func (box BBox) Vec3Within(vec mgl64.Vec3) bool {
 }
 
 // Vec3WithinYZ checks if a BBox has vec within its Y and Z bounds.
-func (box BBox) Vec3WithinYZ(vec mgl64.Vec3) bool {
+func (box boundingBox[T, V]) Vec3WithinYZ(vec V) bool {
 	if vec[2] < box.min[2] || vec[2] > box.max[2] {
 		return false
 	}
@@ -193,7 +230,7 @@ func (box BBox) Vec3WithinYZ(vec mgl64.Vec3) bool {
 }
 
 // Vec3WithinXZ checks if a BBox has vec within its X and Z bounds.
-func (box BBox) Vec3WithinXZ(vec mgl64.Vec3) bool {
+func (box boundingBox[T, V]) Vec3WithinXZ(vec V) bool {
 	if vec[0] < box.min[0] || vec[0] > box.max[0] {
 		return false
 	}
@@ -201,7 +238,7 @@ func (box BBox) Vec3WithinXZ(vec mgl64.Vec3) bool {
 }
 
 // Vec3WithinXY checks if a BBox has vec within its X and Y bounds.
-func (box BBox) Vec3WithinXY(vec mgl64.Vec3) bool {
+func (box boundingBox[T, V]) Vec3WithinXY(vec V) bool {
 	if vec[0] < box.min[0] || vec[0] > box.max[0] {
 		return false
 	}
@@ -211,7 +248,7 @@ func (box BBox) Vec3WithinXY(vec mgl64.Vec3) bool {
 // XOffset calculates the offset on the X axis between two bounding boxes,
 // returning a delta always smaller than or equal to deltaX if deltaX is bigger
 // than 0, or always bigger than or equal to deltaX if it is smaller than 0.
-func (box BBox) XOffset(nearby BBox, deltaX float64) float64 {
+func (box boundingBox[T, V]) XOffset(nearby boundingBox[T, V], deltaX T) T {
 	if box.max[1] <= nearby.min[1] || box.min[1] >= nearby.max[1] || box.max[2] <= nearby.min[2] || box.min[2] >= nearby.max[2] {
 		// Not in the same Y/Z plane.
 		return deltaX
@@ -227,7 +264,7 @@ func (box BBox) XOffset(nearby BBox, deltaX float64) float64 {
 // YOffset calculates the offset on the Y axis between two bounding boxes,
 // returning a delta always smaller than or equal to deltaY if deltaY is bigger
 // than 0, or always bigger than or equal to deltaY if it is smaller than 0.
-func (box BBox) YOffset(nearby BBox, deltaY float64) float64 {
+func (box boundingBox[T, V]) YOffset(nearby boundingBox[T, V], deltaY T) T {
 	if box.max[0] <= nearby.min[0] || box.min[0] >= nearby.max[0] || box.max[2] <= nearby.min[2] || box.min[2] >= nearby.max[2] {
 		// Not the same X/Z plane.
 		return deltaY
@@ -244,7 +281,7 @@ func (box BBox) YOffset(nearby BBox, deltaY float64) float64 {
 // ZOffset calculates the offset on the Z axis between two bounding boxes,
 // returning a delta always smaller than or equal to deltaZ if deltaZ is bigger
 // than 0, or always bigger than or equal to deltaZ if it is smaller than 0.
-func (box BBox) ZOffset(nearby BBox, deltaZ float64) float64 {
+func (box boundingBox[T, V]) ZOffset(nearby boundingBox[T, V], deltaZ T) T {
 	if box.max[0] <= nearby.min[0] || box.min[0] >= nearby.max[0] || box.max[1] <= nearby.min[1] || box.min[1] >= nearby.max[1] {
 		// Not the same X/Y plane.
 		return deltaZ
@@ -259,9 +296,9 @@ func (box BBox) ZOffset(nearby BBox, deltaZ float64) float64 {
 }
 
 // Corners returns the positions of all corners of a BBox.
-func (box BBox) Corners() []mgl64.Vec3 {
+func (box boundingBox[T, V]) Corners() []V {
 	bbmin, bbmax := box.min, box.max
-	return []mgl64.Vec3{
+	return []V{
 		box.min,
 		box.max,
 		{bbmin[0], bbmin[1], bbmax[2]},
@@ -274,11 +311,15 @@ func (box BBox) Corners() []mgl64.Vec3 {
 }
 
 // Mul performs a scalar multiplication of the min and max points of a BBox.
-func (box BBox) Mul(val float64) BBox {
-	return BBox{min: box.min.Mul(val), max: box.max.Mul(val)}
+func (box boundingBox[T, V]) Mul(val T) boundingBox[T, V] {
+	for i := range 3 {
+		box.min[i] *= val
+		box.max[i] *= val
+	}
+	return box
 }
 
 // Volume calculates the volume of a BBox.
-func (box BBox) Volume() float64 {
+func (box boundingBox[T, V]) Volume() T {
 	return box.Height() * box.Length() * box.Width()
 }


### PR DESCRIPTION
## Summary

- share bounding-box geometry across float32 and float64 through a generic implementation
- preserve the existing `BBox` and `Box` float64 API
- add `BBox32`, `Box32`, and `AnyIntersections32` for native `mgl32.Vec3` geometry
- keep all bounding-box operations in their selected precision without conversion

## Motivation

Minecraft Bedrock movement uses float32 arithmetic. Consumers that simulate client movement need collision boxes to remain float32-native so rounding at collision and epsilon boundaries matches the client.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./...`