### PR TITLE
Implement End Crystals

### DIFF
--- a/server/block/bedrock.go
+++ b/server/block/bedrock.go
@@ -20,3 +20,8 @@ func (b Bedrock) EncodeBlock() (name string, properties map[string]any) {
 	//noinspection SpellCheckingInspection
 	return "minecraft:bedrock", map[string]any{"infiniburn_bit": b.InfiniteBurning}
 }
+
+// SupportsEndCrystal always returns true.
+func (Bedrock) SupportsEndCrystal() bool {
+	return true
+}

--- a/server/block/explosion.go
+++ b/server/block/explosion.go
@@ -27,9 +27,9 @@ type ExplosionConfig struct {
 	// SuppressUnderwaterImpact prevents the explosion from affecting entities through liquid layers. Bedrock Edition
 	// applies this to every explosion.
 	SuppressUnderwaterImpact bool
-	// ClipBlocksBelowOrigin prevents the explosion from destroying blocks below its block Y level. Entities below
-	// that level may still be damaged.
-	ClipBlocksBelowOrigin bool
+	// PreventBlockDamageBelowOrigin prevents the explosion from destroying blocks below the block Y level of its
+	// origin. Entity damage is unaffected.
+	PreventBlockDamageBelowOrigin bool
 	// ItemDropChance specifies how item drops should be handled. By default,
 	// the item drop chance is 1/Size. If negative, no items will be dropped by
 	// the explosion. If set to 1 or higher, all items are dropped.
@@ -116,7 +116,7 @@ func (c ExplosionConfig) Explode(tx *world.Tx, src world.ExplosionSource) {
 		pos := explosionPos
 		for blastForce := size * (0.7 + r.Float64()*0.6); blastForce > 0.0; blastForce -= 0.225 {
 			current := cube.PosFromVec3(pos)
-			if c.ClipBlocksBelowOrigin && current.Y() < minY {
+			if c.PreventBlockDamageBelowOrigin && current.Y() < minY {
 				break
 			}
 			currentBlock := tx.Block(current)

--- a/server/block/explosion.go
+++ b/server/block/explosion.go
@@ -24,6 +24,12 @@ type ExplosionConfig struct {
 	// SpawnFire will cause the explosion to randomly start fires in 1/3 of all destroyed air blocks that are
 	// above opaque blocks.
 	SpawnFire bool
+	// SuppressUnderwaterImpact prevents the explosion from affecting entities through liquid layers. Bedrock Edition
+	// applies this to every explosion.
+	SuppressUnderwaterImpact bool
+	// ClipBlocksBelowOrigin prevents the explosion from destroying blocks below its block Y level. Entities below
+	// that level may still be damaged.
+	ClipBlocksBelowOrigin bool
 	// ItemDropChance specifies how item drops should be handled. By default,
 	// the item drop chance is 1/Size. If negative, no items will be dropped by
 	// the explosion. If set to 1 or higher, all items are dropped.
@@ -105,10 +111,14 @@ func (c ExplosionConfig) Explode(tx *world.Tx, src world.ExplosionSource) {
 	}
 
 	affectedBlocks, seen := make([]cube.Pos, 0, 32), make(map[cube.Pos]struct{}, 32)
+	minY := int(math.Floor(explosionPos[1]))
 	for _, ray := range rays {
 		pos := explosionPos
 		for blastForce := size * (0.7 + r.Float64()*0.6); blastForce > 0.0; blastForce -= 0.225 {
 			current := cube.PosFromVec3(pos)
+			if c.ClipBlocksBelowOrigin && current.Y() < minY {
+				break
+			}
 			currentBlock := tx.Block(current)
 
 			resistance, resists := 0.0, false
@@ -143,10 +153,17 @@ func (c ExplosionConfig) Explode(tx *world.Tx, src world.ExplosionSource) {
 	}
 
 	for _, e := range affectedEntities {
-		if explodable, ok := e.(ExplodableEntity); ok {
-			impact := (1 - e.Position().Sub(explosionPos).Len()/d) * exposure(tx, explosionPos, e)
-			explodable.Explode(src, impact)
+		explodable, ok := e.(ExplodableEntity)
+		if !ok {
+			continue
 		}
+		impact := (1 - e.Position().Sub(explosionPos).Len()/d) * c.exposure(tx, explosionPos, e)
+		if c.SuppressUnderwaterImpact && impact <= 0 {
+			// The blast never reached the entity. Skip the call entirely, as entities with a constant damage term,
+			// such as players, would otherwise still be hurt through the liquid that blocked it.
+			continue
+		}
+		explodable.Explode(src, impact)
 	}
 
 	for _, pos := range affectedBlocks {
@@ -183,7 +200,7 @@ func (c ExplosionConfig) Explode(tx *world.Tx, src world.ExplosionSource) {
 }
 
 // exposure returns the exposure of an explosion to an entity, used to calculate the impact of an explosion.
-func exposure(tx *world.Tx, origin mgl64.Vec3, e world.Entity) float64 {
+func (c ExplosionConfig) exposure(tx *world.Tx, origin mgl64.Vec3, e world.Entity) float64 {
 	pos := e.Position()
 	box := e.H().Type().BBox(e).Translate(pos)
 
@@ -209,6 +226,12 @@ func exposure(tx *world.Tx, origin mgl64.Vec3, e world.Entity) float64 {
 				}
 				var collided bool
 				trace.TraverseBlocks(origin, point, func(pos cube.Pos) (cont bool) {
+					if c.SuppressUnderwaterImpact {
+						if _, liquid := tx.Liquid(pos); liquid {
+							collided = true
+							return false
+						}
+					}
 					_, collided = trace.BlockIntercept(pos, tx, tx.Block(pos), origin, point)
 					return !collided
 				})

--- a/server/block/explosion.go
+++ b/server/block/explosion.go
@@ -27,9 +27,6 @@ type ExplosionConfig struct {
 	// SuppressUnderwaterImpact prevents the explosion from affecting entities through liquid layers. Bedrock Edition
 	// applies this to every explosion.
 	SuppressUnderwaterImpact bool
-	// ClipBlocksBelowOrigin prevents the explosion from destroying blocks below its block Y level. Entities below
-	// that level may still be damaged.
-	ClipBlocksBelowOrigin bool
 	// ItemDropChance specifies how item drops should be handled. By default,
 	// the item drop chance is 1/Size. If negative, no items will be dropped by
 	// the explosion. If set to 1 or higher, all items are dropped.
@@ -111,14 +108,10 @@ func (c ExplosionConfig) Explode(tx *world.Tx, src world.ExplosionSource) {
 	}
 
 	affectedBlocks, seen := make([]cube.Pos, 0, 32), make(map[cube.Pos]struct{}, 32)
-	minY := int(math.Floor(explosionPos[1]))
 	for _, ray := range rays {
 		pos := explosionPos
 		for blastForce := size * (0.7 + r.Float64()*0.6); blastForce > 0.0; blastForce -= 0.225 {
 			current := cube.PosFromVec3(pos)
-			if c.ClipBlocksBelowOrigin && current.Y() < minY {
-				break
-			}
 			currentBlock := tx.Block(current)
 
 			resistance, resists := 0.0, false

--- a/server/block/explosion.go
+++ b/server/block/explosion.go
@@ -27,6 +27,9 @@ type ExplosionConfig struct {
 	// SuppressUnderwaterImpact prevents the explosion from affecting entities through liquid layers. Bedrock Edition
 	// applies this to every explosion.
 	SuppressUnderwaterImpact bool
+	// ClipBlocksBelowOrigin prevents the explosion from destroying blocks below its block Y level. Entities below
+	// that level may still be damaged.
+	ClipBlocksBelowOrigin bool
 	// ItemDropChance specifies how item drops should be handled. By default,
 	// the item drop chance is 1/Size. If negative, no items will be dropped by
 	// the explosion. If set to 1 or higher, all items are dropped.
@@ -108,10 +111,14 @@ func (c ExplosionConfig) Explode(tx *world.Tx, src world.ExplosionSource) {
 	}
 
 	affectedBlocks, seen := make([]cube.Pos, 0, 32), make(map[cube.Pos]struct{}, 32)
+	minY := int(math.Floor(explosionPos[1]))
 	for _, ray := range rays {
 		pos := explosionPos
 		for blastForce := size * (0.7 + r.Float64()*0.6); blastForce > 0.0; blastForce -= 0.225 {
 			current := cube.PosFromVec3(pos)
+			if c.ClipBlocksBelowOrigin && current.Y() < minY {
+				break
+			}
 			currentBlock := tx.Block(current)
 
 			resistance, resists := 0.0, false

--- a/server/block/obsidian.go
+++ b/server/block/obsidian.go
@@ -44,6 +44,11 @@ func (o Obsidian) Frame(dimension world.Dimension) bool {
 	return dimension == world.Nether && !o.Crying
 }
 
+// SupportsEndCrystal returns whether an End crystal may be placed on the obsidian.
+func (o Obsidian) SupportsEndCrystal() bool {
+	return !o.Crying
+}
+
 // BreakInfo ...
 func (o Obsidian) BreakInfo() BreakInfo {
 	return newBreakInfo(35, func(t item.Tool) bool {

--- a/server/entity/damageable.go
+++ b/server/entity/damageable.go
@@ -1,0 +1,38 @@
+package entity
+
+import "github.com/df-mc/dragonfly/server/world"
+
+// behaviourDamageable represents a Behaviour that may be hurt directly without
+// implementing Living.
+type behaviourDamageable interface {
+	Hurt(e *Ent, damage float64, src world.DamageSource) (n float64, vulnerable bool)
+}
+
+// HurtEntity hurts an entity if it is either Living or has a Behaviour that may
+// be hurt directly. It returns the damage dealt, whether the entity was
+// vulnerable to the damage, and whether the entity could be damaged.
+func HurtEntity(e world.Entity, damage float64, src world.DamageSource) (n float64, vulnerable, ok bool) {
+	if l, ok := e.(Living); ok {
+		n, vulnerable = l.Hurt(damage, src)
+		return n, vulnerable, true
+	}
+	if ent, ok := e.(*Ent); ok {
+		if d, ok := ent.Behaviour().(behaviourDamageable); ok {
+			n, vulnerable = d.Hurt(ent, damage, src)
+			return n, vulnerable, true
+		}
+	}
+	return 0, false, false
+}
+
+// DamageableEntity checks if an entity may be damaged.
+func DamageableEntity(e world.Entity) bool {
+	if _, ok := e.(Living); ok {
+		return true
+	}
+	if ent, ok := e.(*Ent); ok {
+		_, ok = ent.Behaviour().(behaviourDamageable)
+		return ok
+	}
+	return false
+}

--- a/server/entity/end_crystal.go
+++ b/server/entity/end_crystal.go
@@ -1,0 +1,85 @@
+package entity
+
+import (
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/internal/nbtconv"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+// NewEndCrystal creates a new End crystal entity.
+func NewEndCrystal(opts world.EntitySpawnOpts) *world.EntityHandle {
+	return EndCrystalConfig{}.New(opts)
+}
+
+// EndCrystalConfig holds configuration for an End crystal entity.
+type EndCrystalConfig struct {
+	// ExplosionSize is the size of the explosion created when the End crystal is destroyed. It defaults to 6.
+	ExplosionSize float64
+	// ShowBase specifies whether the End crystal renders its bottom base.
+	ShowBase bool
+}
+
+// New creates an End crystal entity with the configuration c.
+func (c EndCrystalConfig) New(opts world.EntitySpawnOpts) *world.EntityHandle {
+	return opts.New(EndCrystalType, c)
+}
+
+// Apply applies the End crystal configuration to data.
+func (c EndCrystalConfig) Apply(data *world.EntityData) {
+	if c.ExplosionSize == 0 {
+		c.ExplosionSize = 6
+	}
+	data.Data = endCrystalBehaviour{
+		showBase:      c.ShowBase,
+		explosionSize: c.ExplosionSize,
+	}
+}
+
+// EndCrystalType is a world.EntityType implementation for End crystals.
+var EndCrystalType endCrystalType
+
+type endCrystalType struct{}
+
+func (endCrystalType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
+	return Open(tx, handle, data)
+}
+
+func (endCrystalType) EncodeEntity() string {
+	return "minecraft:ender_crystal"
+}
+
+func (endCrystalType) BBox(world.Entity) cube.BBox {
+	return cube.Box(-1, 0, -1, 1, 2, 1)
+}
+
+func (endCrystalType) DecodeNBT(m map[string]any, data *world.EntityData) {
+	b := endCrystalBehaviour{
+		showBase:      nbtconv.Bool(m, "ShowBottom"),
+		explosionSize: nbtconv.Float64(m, "ExplosionSize"),
+	}
+	if b.explosionSize == 0 {
+		b.explosionSize = 6
+	}
+	x, hasX := m["BlockTargetX"].(int32)
+	y, hasY := m["BlockTargetY"].(int32)
+	z, hasZ := m["BlockTargetZ"].(int32)
+	if hasX && hasY && hasZ {
+		b.beamTarget = cube.Pos{int(x), int(y), int(z)}
+		b.hasBeamTarget = true
+	}
+	b.Apply(data)
+}
+
+func (endCrystalType) EncodeNBT(data *world.EntityData) map[string]any {
+	b := data.Data.(endCrystalBehaviour)
+	m := map[string]any{
+		"ShowBottom":    boolByte(b.showBase),
+		"ExplosionSize": b.explosionSize,
+	}
+	if b.hasBeamTarget {
+		m["BlockTargetX"] = int32(b.beamTarget[0])
+		m["BlockTargetY"] = int32(b.beamTarget[1])
+		m["BlockTargetZ"] = int32(b.beamTarget[2])
+	}
+	return m
+}

--- a/server/entity/end_crystal_behaviour.go
+++ b/server/entity/end_crystal_behaviour.go
@@ -1,0 +1,76 @@
+package entity
+
+import (
+	"github.com/df-mc/dragonfly/server/block"
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+type endCrystalBehaviour struct {
+	showBase      bool
+	beamTarget    cube.Pos
+	hasBeamTarget bool
+	explosionSize float64
+}
+
+func (b endCrystalBehaviour) Apply(data *world.EntityData) {
+	data.Data = b
+}
+
+// Tick continuously generates fire at the End crystal's position while in the
+// End, if the block at that position is air.
+func (endCrystalBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
+	if tx.World().Dimension() == world.End {
+		block.Fire{}.Start(tx, cube.PosFromVec3(e.Position()))
+	}
+	return nil
+}
+
+// Explode makes the End crystal explode itself when hit by another explosion,
+// causing a chain reaction.
+func (b endCrystalBehaviour) Explode(e *Ent, _ world.ExplosionSource, impact float64) {
+	if impact <= 0 {
+		return
+	}
+	explodeEndCrystal(e, b.explosionSize)
+}
+
+// Hurt makes the End crystal explode when damaged by any source, even by
+// damage that deals no health. Void damage removes it without an explosion.
+func (b endCrystalBehaviour) Hurt(e *Ent, damage float64, src world.DamageSource) (float64, bool) {
+	damage = max(damage, 0)
+	if _, ok := src.(VoidDamageSource); ok {
+		_ = e.Close()
+		return damage, true
+	}
+	explodeEndCrystal(e, b.explosionSize)
+	return damage, true
+}
+
+func (endCrystalBehaviour) Immobile() bool {
+	return true
+}
+
+func (b endCrystalBehaviour) ShowBase() bool {
+	return b.showBase
+}
+
+func (b endCrystalBehaviour) BeamTarget() (cube.Pos, bool) {
+	return b.beamTarget, b.hasBeamTarget
+}
+
+// explodeEndCrystal closes the End crystal and creates a non-incendiary
+// explosion at its base, if the crystal was not closed yet.
+func explodeEndCrystal(e *Ent, explosionSize float64) {
+	if _, ok := e.H().Entity(e.tx); !ok {
+		return
+	}
+	_ = e.Close()
+	block.ExplosionConfig{
+		SuppressUnderwaterImpact: true,
+		ClipBlocksBelowOrigin:    true,
+	}.Explode(e.tx, world.EntityExplosionSource{
+		Entity:        e,
+		ExplosionSize: explosionSize,
+	})
+}

--- a/server/entity/end_crystal_behaviour.go
+++ b/server/entity/end_crystal_behaviour.go
@@ -68,7 +68,6 @@ func explodeEndCrystal(e *Ent, explosionSize float64) {
 	_ = e.Close()
 	block.ExplosionConfig{
 		SuppressUnderwaterImpact: true,
-		ClipBlocksBelowOrigin:    true,
 	}.Explode(e.tx, world.EntityExplosionSource{
 		Entity:        e,
 		ExplosionSize: explosionSize,

--- a/server/entity/end_crystal_behaviour.go
+++ b/server/entity/end_crystal_behaviour.go
@@ -67,8 +67,8 @@ func explodeEndCrystal(e *Ent, explosionSize float64) {
 	}
 	_ = e.Close()
 	block.ExplosionConfig{
-		SuppressUnderwaterImpact: true,
-		ClipBlocksBelowOrigin:    true,
+		SuppressUnderwaterImpact:      true,
+		PreventBlockDamageBelowOrigin: true,
 	}.Explode(e.tx, world.EntityExplosionSource{
 		Entity:        e,
 		ExplosionSize: explosionSize,

--- a/server/entity/end_crystal_behaviour.go
+++ b/server/entity/end_crystal_behaviour.go
@@ -68,6 +68,7 @@ func explodeEndCrystal(e *Ent, explosionSize float64) {
 	_ = e.Close()
 	block.ExplosionConfig{
 		SuppressUnderwaterImpact: true,
+		ClipBlocksBelowOrigin:    true,
 	}.Explode(e.tx, world.EntityExplosionSource{
 		Entity:        e,
 		ExplosionSize: explosionSize,

--- a/server/entity/projectile.go
+++ b/server/entity/projectile.go
@@ -195,11 +195,11 @@ func (lt *ProjectileBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 
 	switch r := result.(type) {
 	case trace.EntityResult:
-		if l, ok := r.Entity().(Living); ok {
-			if lt.conf.Damage >= 0 {
-				lt.hitEntity(l, e, vel)
-			}
-			lt.collidedEntities = append(lt.collidedEntities, l.H())
+		if lt.conf.Damage >= 0 {
+			lt.hitEntity(r.Entity(), e, vel)
+		}
+		if DamageableEntity(r.Entity()) {
+			lt.collidedEntities = append(lt.collidedEntities, r.Entity().H())
 		}
 	case trace.BlockResult:
 		bpos := r.BlockPosition()
@@ -288,10 +288,9 @@ func (lt *ProjectileBehaviour) hitBlockSurviving(e *Ent, r trace.BlockResult, m 
 	}
 }
 
-// hitEntity is called when a projectile hits a Living. It deals damage to the
-// entity and knocks it back. Additionally, it applies any potion effects and
-// fire if applicable.
-func (lt *ProjectileBehaviour) hitEntity(l Living, e *Ent, vel mgl64.Vec3) {
+// hitEntity is called when a projectile hits an entity. It deals damage to the
+// entity if possible, and applies Living-specific effects such as knockback.
+func (lt *ProjectileBehaviour) hitEntity(victim world.Entity, e *Ent, vel mgl64.Vec3) {
 	owner, _ := lt.conf.Owner.Entity(e.tx)
 	src := ProjectileDamageSource{Projectile: e, Owner: owner}
 	dmg := math.Ceil(lt.conf.Damage * vel.Len())
@@ -299,7 +298,11 @@ func (lt *ProjectileBehaviour) hitEntity(l Living, e *Ent, vel mgl64.Vec3) {
 		dmg += rand.Float64() * dmg / 2
 	}
 	// TODO: Piercing arrows should bypass shield blocking when shields are implemented.
-	if _, vulnerable := l.Hurt(dmg, src); vulnerable {
+	if _, vulnerable, ok := HurtEntity(victim, dmg, src); ok && vulnerable {
+		l, ok := victim.(Living)
+		if !ok {
+			return
+		}
 		l.KnockBack(l.Position().Sub(vel), 0.45+lt.conf.KnockBackForceAddend, 0.3608+lt.conf.KnockBackHeightAddend)
 
 		for _, eff := range lt.conf.Potion.Effects() {
@@ -357,7 +360,7 @@ func (lt *ProjectileBehaviour) tickMovement(e *Ent, tx *world.Tx) (*Movement, tr
 }
 
 // ignores returns a function to ignore entities in trace.Perform that are
-// either a spectator, not living, the entity itself, its owner in the first
+// either a spectator, not damageable, the entity itself, its owner in the first
 // 5 ticks, or an entity it already collided with.
 func (lt *ProjectileBehaviour) ignores(e *Ent) trace.EntityFilter {
 	return func(seq iter.Seq[world.Entity]) iter.Seq[world.Entity] {
@@ -366,10 +369,10 @@ func (lt *ProjectileBehaviour) ignores(e *Ent) trace.EntityFilter {
 				g, ok := other.(interface{ GameMode() world.GameMode })
 				spectator := ok && !g.GameMode().HasCollision()
 				itself := e.H() == other.H()
-				_, living := other.(Living)
+				damageable := DamageableEntity(other)
 				owner := e.data.Age < time.Second/4 && lt.conf.Owner == other.H()
 				collidedEntity := slices.Contains(lt.collidedEntities, other.H())
-				if spectator || itself || !living || owner || collidedEntity {
+				if spectator || itself || !damageable || owner || collidedEntity {
 					continue
 				}
 				if !yield(other) {

--- a/server/entity/register.go
+++ b/server/entity/register.go
@@ -14,6 +14,7 @@ var DefaultRegistry = conf.New([]world.EntityType{
 	ArrowType,
 	BottleOfEnchantingType,
 	EggType,
+	EndCrystalType,
 	EnderPearlType,
 	ExperienceOrbType,
 	FallingBlockType,
@@ -30,6 +31,7 @@ var DefaultRegistry = conf.New([]world.EntityType{
 var conf = world.EntityRegistryConfig{
 	TNT:                NewTNT,
 	Egg:                NewEgg,
+	EndCrystal:         NewEndCrystal,
 	Snowball:           NewSnowball,
 	BottleOfEnchanting: NewBottleOfEnchanting,
 	EnderPearl:         NewEnderPearl,

--- a/server/item/end_crystal.go
+++ b/server/item/end_crystal.go
@@ -1,0 +1,50 @@
+package item
+
+import (
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/go-gl/mathgl/mgl64"
+)
+
+// EndCrystal is an item that can be placed on obsidian or bedrock to spawn an End crystal entity.
+type EndCrystal struct{}
+
+// endCrystalSupport represents a block that supports an End crystal.
+type endCrystalSupport interface {
+	SupportsEndCrystal() bool
+}
+
+// UseOnBlock places an End crystal on top of the clicked block if it is
+// obsidian or bedrock, the two blocks above it are air and no other entities
+// intersect the space the crystal is placed in. The face clicked is ignored.
+func (e EndCrystal) UseOnBlock(pos cube.Pos, _ cube.Face, _ mgl64.Vec3, tx *world.Tx, user User, ctx *UseContext) bool {
+	support, ok := tx.Block(pos).(endCrystalSupport)
+	if !ok || !support.SupportsEndCrystal() {
+		return false
+	}
+
+	above, twoAbove := pos.Side(cube.FaceUp), pos.Side(cube.FaceUp).Side(cube.FaceUp)
+	if above.OutOfBounds(tx.Range()) || twoAbove.OutOfBounds(tx.Range()) {
+		return false
+	}
+	if tx.Block(above) != air() || tx.Block(twoAbove) != air() {
+		return false
+	}
+
+	box := cube.Box(0, 0, 0, 1, 2, 1).Translate(above.Vec3())
+	for entity := range tx.EntitiesWithin(box.Grow(2)) {
+		if entity.H() != user.H() && entity.H().Type().BBox(entity).Translate(entity.Position()).IntersectsWith(box) {
+			return false
+		}
+	}
+
+	opts := world.EntitySpawnOpts{Position: pos.Vec3().Add(mgl64.Vec3{0.5, 1, 0.5})}
+	tx.AddEntity(tx.World().EntityRegistry().Config().EndCrystal(opts))
+	ctx.SubtractFromCount(1)
+	return true
+}
+
+// EncodeItem ...
+func (EndCrystal) EncodeItem() (name string, meta int16) {
+	return "minecraft:end_crystal", 0
+}

--- a/server/item/register.go
+++ b/server/item/register.go
@@ -52,6 +52,7 @@ func init() {
 	world.RegisterItem(Emerald{})
 	world.RegisterItem(EnchantedApple{})
 	world.RegisterItem(EnchantedBook{})
+	world.RegisterItem(EndCrystal{})
 	world.RegisterItem(EnderEye{})
 	world.RegisterItem(EnderPearl{})
 	world.RegisterItem(Feather{})

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1855,7 +1855,19 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 	p.SwingArm()
 
 	if !isLiving {
-		return false
+		if !entity.DamageableEntity(e) {
+			return false
+		}
+		i, left := p.HeldItems()
+		if durable, ok := i.Item().(item.Durable); ok {
+			p.SetHeldItems(p.damageItem(i, durable.DurabilityInfo().AttackDurability), left)
+		}
+		n, vulnerable, _ := entity.HurtEntity(e, i.AttackDamage(), entity.AttackDamageSource{Attacker: p})
+		p.tx.PlaySound(entity.EyePosition(e), sound.Attack{Damage: !mgl64.FloatEqual(n, 0)})
+		if vulnerable {
+			p.Exhaust(0.1)
+		}
+		return true
 	}
 
 	dmg := i.AttackDamage()

--- a/server/session/entity_metadata.go
+++ b/server/session/entity_metadata.go
@@ -113,6 +113,16 @@ func (s *Session) addSpecificMetadata(e any, m protocol.EntityMetadata) {
 	if sc, ok := e.(scoreTag); ok {
 		m[protocol.EntityDataKeyScore] = sc.ScoreTag()
 	}
+	if c, ok := e.(endCrystal); ok {
+		if c.ShowBase() {
+			m.SetFlag(protocol.EntityDataKeyFlags, protocol.EntityDataFlagShowBottom)
+		} else {
+			m.UnsetFlag(protocol.EntityDataKeyFlags, protocol.EntityDataFlagShowBottom)
+		}
+		if target, ok := c.BeamTarget(); ok {
+			m[protocol.EntityDataKeyBlockTarget] = protocol.BlockPos{int32(target[0]), int32(target[1]), int32(target[2])}
+		}
+	}
 	if sl, ok := e.(sleeper); ok {
 		if pos, ok := sl.Sleeping(); ok {
 			m[protocol.EntityDataKeyBedPosition] = protocol.BlockPos{int32(pos[0]), int32(pos[1]), int32(pos[2])}
@@ -268,6 +278,11 @@ type alwaysShowNameTag interface {
 
 type scoreTag interface {
 	ScoreTag() string
+}
+
+type endCrystal interface {
+	ShowBase() bool
+	BeamTarget() (cube.Pos, bool)
 }
 
 type splash interface {

--- a/server/world/entity.go
+++ b/server/world/entity.go
@@ -496,6 +496,7 @@ type EntityRegistryConfig struct {
 	BottleOfEnchanting func(opts EntitySpawnOpts, owner Entity) *EntityHandle
 	Arrow              func(opts EntitySpawnOpts, conf ArrowSpawnConfig) *EntityHandle
 	Egg                func(opts EntitySpawnOpts, owner Entity) *EntityHandle
+	EndCrystal         func(opts EntitySpawnOpts) *EntityHandle
 	EnderPearl         func(opts EntitySpawnOpts, owner Entity) *EntityHandle
 	Firework           func(opts EntitySpawnOpts, firework Item, owner Entity, sidewaysVelocityMultiplier, upwardsAcceleration float64, attached bool) *EntityHandle
 	LingeringPotion    func(opts EntitySpawnOpts, t any, owner Entity) *EntityHandle


### PR DESCRIPTION
This PR was split from https://github.com/df-mc/dragonfly/pull/1247 so End crystals can be reviewed independently from respawn anchors.

- Adds End crystal placement on obsidian and bedrock with vanilla air-space and entity-collision checks.
- Adds the End crystal entity, registration, metadata, persistence, direct/projectile damage handling, explosion chaining, and void-damage behaviour.
- Adds configurable explosion size through `entity.EndCrystalConfig`, retaining the vanilla radius of 6 by default.
- Prevents End-crystal explosions from affecting entities through liquid layers, matching the Bedrock `allow_underwater: false` default.

Verification:
- `go test ./...`
- `make lint`
- `git diff --check`
