### PR TITLE
world: add portal lifecycle handlers

### DIFF
--- a/server/entity/travel.go
+++ b/server/entity/travel.go
@@ -256,7 +256,7 @@ func (t *PortalTravelComputer) transfer(handle *world.EntityHandle, source, dest
 }
 
 // destinationSpawn returns the position the entity should be placed at in the destination world. False is returned
-// if no linked nether portal was found and the entity may not create one.
+// if no linked nether portal was found and none could be created.
 func (t *PortalTravelComputer) destinationSpawn(tx *world.Tx, sourceDim world.Dimension, pos cube.Pos) (mgl64.Vec3, bool) {
 	if tx.World().Dimension() == world.End {
 		portal.GenerateEndSpawnPlatform(tx)
@@ -279,7 +279,7 @@ func (t *PortalTravelComputer) destinationSpawn(tx *world.Tx, sourceDim world.Di
 	if n, ok := portal.FindOrCreateNetherPortal(tx, pos, portalSearchRadius); ok {
 		return n.Spawn().Vec3Middle(), true
 	}
-	return pos.Vec3Middle(), true
+	return mgl64.Vec3{}, false
 }
 
 // finishTravel runs the post-transfer portal hook and places the traveller at

--- a/server/world/handler.go
+++ b/server/world/handler.go
@@ -49,6 +49,14 @@ type Handler interface {
 	// Leaves decaying happens when there is no wood block neighbouring it.
 	// ctx.Cancel() may be called to prevent leaves from decaying.
 	HandleLeavesDecay(ctx *Context, pos cube.Pos)
+	// HandlePortalCreate handles an active portal being built. portalType is
+	// Nether or End, and positions contains every block changed to build it.
+	// ctx.Cancel() may be called to prevent the portal from being built.
+	HandlePortalCreate(ctx *Context, portalType Dimension, positions []cube.Pos)
+	// HandlePortalActivate handles a portal frame being filled with portal
+	// blocks. portalType is Nether or End. ctx.Cancel() may be called to prevent
+	// the portal from being activated.
+	HandlePortalActivate(ctx *Context, portalType Dimension, positions []cube.Pos)
 	// HandleEntitySpawn handles an Entity being spawned into a World through a
 	// call to Tx.AddEntity or Tx.AddEntityAt.
 	HandleEntitySpawn(tx *Tx, e Entity)
@@ -86,6 +94,8 @@ func (NopHandler) HandleFireSpread(*Context, cube.Pos, cube.Pos)                
 func (NopHandler) HandleBlockBurn(*Context, cube.Pos)                           {}
 func (NopHandler) HandleCropTrample(*Context, cube.Pos)                         {}
 func (NopHandler) HandleLeavesDecay(*Context, cube.Pos)                         {}
+func (NopHandler) HandlePortalCreate(*Context, Dimension, []cube.Pos)           {}
+func (NopHandler) HandlePortalActivate(*Context, Dimension, []cube.Pos)         {}
 func (NopHandler) HandleEntitySpawn(*Tx, Entity)                                {}
 func (NopHandler) HandleEntityDespawn(*Tx, Entity)                              {}
 func (NopHandler) HandleExplosion(*Context, ExplosionSource, *[]Entity, *[]cube.Pos, *float64, *bool) {

--- a/server/world/portal/end.go
+++ b/server/world/portal/end.go
@@ -66,6 +66,21 @@ func ActivateEndPortal(tx *world.Tx, framePos cube.Pos) bool {
 			continue
 		}
 		ep := endPortal()
+		active := true
+		for _, pos := range interior {
+			if tx.Block(pos) != ep {
+				active = false
+				break
+			}
+		}
+		if active {
+			return false
+		}
+		ctx := tx.Event()
+		positions := append([]cube.Pos(nil), interior...)
+		if tx.World().Handler().HandlePortalActivate(ctx, world.End, positions); ctx.Cancelled() {
+			return false
+		}
 		for _, pos := range interior {
 			if tx.Block(pos) != ep {
 				tx.SetBlock(pos, ep, nil)

--- a/server/world/portal/nether.go
+++ b/server/world/portal/nether.go
@@ -56,6 +56,11 @@ func ActivateNetherPortal(tx *world.Tx, pos cube.Pos) bool {
 	if !ok || !p.Framed() || p.Activated() {
 		return false
 	}
+	ctx := tx.Event()
+	positions := append([]cube.Pos(nil), p.Positions()...)
+	if tx.World().Handler().HandlePortalActivate(ctx, world.Nether, positions); ctx.Cancelled() {
+		return false
+	}
 	p.Activate()
 	return true
 }
@@ -218,6 +223,18 @@ func CreateNetherPortal(tx *world.Tx, pos cube.Pos) (Nether, bool) {
 		axis = cube.Z
 	}
 
+	// Buffer the blocks the portal is made up of so a world.Handler may cancel the creation before any of them are
+	// written to the world. affected holds each position exactly once, in the order it was first set.
+	ob, pb := obsidian(), portal(axis)
+	blocks := make(map[cube.Pos]world.Block)
+	var affected []cube.Pos
+	setBlock := func(pos cube.Pos, b world.Block) {
+		if _, ok := blocks[pos]; !ok {
+			affected = append(affected, pos)
+		}
+		blocks[pos] = b
+	}
+
 	if distance < 0.0 {
 		// If all else fails, we can simply create a floating platform in the void with the portal on it.
 		resultPos[1] = min(max(resultPos[1], 70), r.Max()-10)
@@ -230,9 +247,10 @@ func CreateNetherPortal(tx *world.Tx, pos cube.Pos) (Nether, bool) {
 						resultPos.Z() + safeWidth*coEff2 - safeBeforeAfter*coEff1,
 					}
 
-					tx.SetBlock(entryPos, nil, nil)
 					if height < 0 {
-						tx.SetBlock(entryPos, obsidian(), nil)
+						setBlock(entryPos, ob)
+					} else {
+						setBlock(entryPos, nil)
 					}
 				}
 			}
@@ -250,12 +268,21 @@ func CreateNetherPortal(tx *world.Tx, pos cube.Pos) (Nether, bool) {
 			}
 
 			if width == -1 || width == 2 || height == -1 || height == 3 {
-				tx.SetBlock(entryPos, obsidian(), nil)
+				setBlock(entryPos, ob)
 				continue
 			}
 			positions = append(positions, entryPos)
-			tx.SetBlock(entryPos, portal(axis), nil)
+			setBlock(entryPos, pb)
 		}
+	}
+
+	ctx := tx.Event()
+	handlerPositions := append([]cube.Pos(nil), affected...)
+	if tx.World().Handler().HandlePortalCreate(ctx, world.Nether, handlerPositions); ctx.Cancelled() {
+		return Nether{}, false
+	}
+	for _, pos := range affected {
+		tx.SetBlock(pos, blocks[pos], nil)
 	}
 
 	return Nether{

--- a/server/world/redstone_test.go
+++ b/server/world/redstone_test.go
@@ -28,6 +28,8 @@ func (minimalRedstoneTestHandler) HandleFireSpread(*Context, cube.Pos, cube.Pos)
 func (minimalRedstoneTestHandler) HandleBlockBurn(*Context, cube.Pos)                           {}
 func (minimalRedstoneTestHandler) HandleCropTrample(*Context, cube.Pos)                         {}
 func (minimalRedstoneTestHandler) HandleLeavesDecay(*Context, cube.Pos)                         {}
+func (minimalRedstoneTestHandler) HandlePortalCreate(*Context, Dimension, []cube.Pos)           {}
+func (minimalRedstoneTestHandler) HandlePortalActivate(*Context, Dimension, []cube.Pos)         {}
 func (minimalRedstoneTestHandler) HandleEntitySpawn(*Tx, Entity)                                {}
 func (minimalRedstoneTestHandler) HandleEntityDespawn(*Tx, Entity)                              {}
 func (minimalRedstoneTestHandler) HandleExplosion(*Context, ExplosionSource, *[]Entity, *[]cube.Pos, *float64, *bool) {


### PR DESCRIPTION
## Summary

- add cancellable world handlers for portal creation and activation
- dispatch activation hooks for framed Nether and End portals before block changes
- buffer automatic Nether portal construction so cancellation leaves the destination unchanged
- abort portal travel cleanly when destination portal creation is cancelled

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`

Closes #1353