### PR TITLE
ci: securely deploy pull request artifacts

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,3 +25,13 @@ jobs:
         run: |
           go generate ./server/block/
           git diff --exit-code
+
+      - name: Build deployment artifact
+        run: go build -o dragonfly_exe -v .
+
+      - name: Upload deployment artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: dragonfly_exe
+          archive: false
+          retention-days: 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Upload deployment artifact
         uses: actions/upload-artifact@v7
         with:
+          # Direct uploads use the file name as the artifact name.
           path: dragonfly_exe
           archive: false
           retention-days: 1

--- a/.github/workflows/pr_target.yml
+++ b/.github/workflows/pr_target.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 jobs:
 
@@ -17,12 +18,38 @@ jobs:
     if: >-
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.pull_requests[0] != null
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
 
+      - name: Resolve pull request
+        id: pull_request
+        uses: actions/github-script@v8
+        env:
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const {data: pulls} = await github.rest.pulls.list({
+              ...context.repo,
+              state: 'open',
+              head: `${process.env.HEAD_OWNER}:${process.env.HEAD_BRANCH}`,
+              per_page: 100,
+            });
+            const matches = pulls.filter(pull => pull.head.sha === process.env.HEAD_SHA);
+            if (matches.length > 1) {
+              core.setFailed(`Expected at most one matching pull request, found ${matches.length}.`);
+              return;
+            }
+            if (matches.length === 0) {
+              core.notice('The workflow run no longer belongs to the current head of an open pull request.');
+              return;
+            }
+            core.setOutput('number', matches[0].number);
+
       - name: Download deployment artifact
+        if: steps.pull_request.outputs.number != ''
         uses: actions/download-artifact@v8
         with:
           name: dragonfly_exe
@@ -30,11 +57,13 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Deploy test server
+        if: steps.pull_request.outputs.number != ''
         env:
           API_KEY: ${{ secrets.API_KEY }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
         run: |
-          curl -X POST https://df-mc.dev/pullrequest \
+          curl --fail-with-body --silent --show-error \
+            -X POST https://df-mc.dev/pullrequest \
             -H "X-API-Key: $API_KEY" \
             -F "pr=$PR_NUMBER" \
             -F "binary=@dragonfly_exe"
@@ -49,5 +78,6 @@ jobs:
           API_KEY: ${{ secrets.API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          curl -X DELETE "https://df-mc.dev/pullrequest/$PR_NUMBER" \
+          curl --fail-with-body --silent --show-error \
+            -X DELETE "https://df-mc.dev/pullrequest/$PR_NUMBER" \
             -H "X-API-Key: $API_KEY"

--- a/.github/workflows/pr_target.yml
+++ b/.github/workflows/pr_target.yml
@@ -1,41 +1,53 @@
 name: Deploy
 on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
   pull_request_target:
-    types: [opened, synchronize, reopened, closed]
+    types: [closed]
+
+permissions:
+  actions: read
+  contents: read
+
 jobs:
 
   deploy:
     name: Deploy
-    if: github.event.action != 'closed'
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0] != null
     runs-on: ubuntu-latest
     steps:
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v6
+      - name: Download deployment artifact
+        uses: actions/download-artifact@v8
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Build
-        run: go build -o dragonfly_exe -v .
+          name: dragonfly_exe
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Deploy test server
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
           curl -X POST https://df-mc.dev/pullrequest \
-            -H "X-API-Key: ${{ secrets.API_KEY }}" \
-            -F "pr=${{ github.event.pull_request.number }}" \
+            -H "X-API-Key: $API_KEY" \
+            -F "pr=$PR_NUMBER" \
             -F "binary=@dragonfly_exe"
 
   cleanup:
     name: Cleanup
-    if: github.event.action == 'closed'
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: Delete test server
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          curl -X DELETE https://df-mc.dev/pullrequest/${{ github.event.pull_request.number }} \
-            -H "X-API-Key: ${{ secrets.API_KEY }}"
+          curl -X DELETE "https://df-mc.dev/pullrequest/$PR_NUMBER" \
+            -H "X-API-Key: $API_KEY"


### PR DESCRIPTION
## What changed

- build the pull request deployment binary in the unprivileged pull_request workflow
- upload the binary as a short-lived, unarchived artifact
- deploy successful artifacts from a least-privilege workflow_run job
- resolve fork pull requests from the trusted head repository, branch, and SHA fields instead of workflow_run.pull_requests
- ignore stale runs whose SHA is no longer the current head of an open pull request
- make deployment and cleanup fail on HTTP errors
- keep test-server cleanup on the trusted pull_request_target close event

## Why

actions/checkout@v6 now refuses to check out fork pull request code from a privileged pull_request_target workflow. The previous deployment job checked out and built the pull request merge ref while holding the base repository token and deployment secret.

Separating the build from deployment restores fork PR deployments without opting out of checkout protection. The trusted job treats the downloaded binary as opaque data and only uploads it to the existing test-server API.

Fork workflow runs can have an empty pull_requests array, including this PR actual Build run. The trusted workflow therefore resolves the PR through the GitHub API and requires the event head SHA to match the current open PR head before deploying.

## Validation

- make lint
- go test ./...
- go generate ./server/block/ followed by git diff --exit-code
- go build -o /tmp/dragonfly-pr-deployment-verify -v .
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/pr.yml .github/workflows/pr_target.yml
- fork-local workflow_run probe: HashimTheArab/dragonfly/actions/runs/30167830315
  - resolved PR 63 from trusted event fields
  - downloaded the raw dragonfly_exe artifact from Build run 30167801011
  - verified the server-provided SHA-256 digest
  - confirmed the downloaded file was a non-empty 64-bit ELF
  - legacy deployment and cleanup jobs were repository-gated and skipped; df-mc.dev was not called

No Go tests were added because this change only affects GitHub Actions wiring.