### PR TITLE
server/entity: reduce movement collision scan overhead

### DIFF
--- a/server/entity/movement.go
+++ b/server/entity/movement.go
@@ -174,15 +174,23 @@ func blockBBoxsAround(tx *world.Tx, box cube.BBox) []cube.BBox {
 	grown := box.Grow(0.25)
 	min, max := grown.Min(), grown.Max()
 	minX, minY, minZ := int(math.Floor(min[0])), int(math.Floor(min[1])), int(math.Floor(min[2]))
+	// The maximum bounds are exclusive: A block starting exactly at the box's
+	// maximum cannot collide with it.
 	maxX, maxY, maxZ := int(math.Ceil(max[0])), int(math.Ceil(max[1])), int(math.Ceil(max[2]))
 
-	// A prediction of one BBox per block, plus an additional 2, in case
-	blockBBoxs := make([]cube.BBox, 0, (maxX-minX)*(maxY-minY)*(maxZ-minZ)+2)
-	for y := minY; y <= maxY; y++ {
-		for x := minX; x <= maxX; x++ {
-			for z := minZ; z <= maxZ; z++ {
+	// A prediction of one BBox per block, plus an additional 2, in case. Allocate
+	// it lazily so that entities moving through air do not allocate an empty slice
+	// every tick.
+	predicted := (maxX-minX)*(maxY-minY)*(maxZ-minZ) + 2
+	var blockBBoxs []cube.BBox
+	for y := minY; y < maxY; y++ {
+		for x := minX; x < maxX; x++ {
+			for z := minZ; z < maxZ; z++ {
 				pos := cube.Pos{x, y, z}
 				boxes := tx.Block(pos).Model().BBox(pos, tx)
+				if len(boxes) != 0 && blockBBoxs == nil {
+					blockBBoxs = make([]cube.BBox, 0, predicted)
+				}
 				for _, box := range boxes {
 					blockBBoxs = append(blockBBoxs, box.Translate(mgl64.Vec3{float64(x), float64(y), float64(z)}))
 				}


### PR DESCRIPTION
## Summary

Reduce entity movement collision overhead by:

- treating the calculated maximum block coordinates as exclusive bounds, avoiding an extra positive block layer on every axis;
- allocating the collision BBox slice only after a block with a non-empty collision model is found.

`blockBBoxsAround` already calculates each maximum with `ceil`. A block beginning at that coordinate is at or beyond the predicted BBox's maximum edge and cannot intersect it. For a common falling sand/gravel BBox, the inclusive loops could inspect 64 block positions where 27 are sufficient.

This primarily targets large groups of falling blocks, but all entities using `MovementComputer` benefit. Collision axis ordering, movement results, falling-block placement, block updates, damage, drops, and tick timing remain unchanged.

## Benchmarks

Apple M3 Pro, Go 1.26.2, darwin/arm64. Paired medians from 5 runs with 1,000 entities:

| Scenario | CPU before | CPU after | CPU saved | Bytes before | Bytes after | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Sand, airborne tick | 2.799 ms | 1.450 ms | 48.2% | 2.362 MiB | 0.820 MiB | 3,950 | 2,789 |
| Sand, landing tick | 10.830 ms | 6.053 ms | 44.1% | 6.528 MiB | 5.772 MiB | 30,930 | 20,803 |
| Gravel, airborne tick | 2.203 ms | 0.876 ms | 60.2% | 2.362 MiB | 0.820 MiB | 3,950 | 2,789 |
| Gravel, landing tick | 9.469 ms | 6.450 ms | 31.9% | 6.524 MiB | 5.767 MiB | 26,060 | 15,931 |

The benchmark harness and complete paired results are available in [HashimTheArab/dragonfly#59](https://github.com/HashimTheArab/dragonfly/pull/59).

## Validation

- `gofmt -w server/entity/movement.go`
- `git diff --check upstream/master...HEAD`
- `go test ./...`
