### PR TITLE
server/block: reduce explosion selection overhead

### DIFF
--- a/server/block/explosion.go
+++ b/server/block/explosion.go
@@ -52,6 +52,17 @@ type Explodable interface {
 	Explode(src world.ExplosionSource, pos cube.Pos, tx *world.Tx)
 }
 
+type explosionBlockInfo struct {
+	resistance float64
+	flags      uint8
+}
+
+const (
+	explosionBlockResists uint8 = 1 << iota
+	explosionBlockStopsRay
+	explosionBlockAffected
+)
+
 // rays ...
 var rays = make([]mgl64.Vec3, 0, 1352)
 
@@ -107,33 +118,45 @@ func (c ExplosionConfig) Explode(tx *world.Tx, src world.ExplosionSource) {
 		affectedEntities = append(affectedEntities, e)
 	}
 
-	affectedBlocks, seen := make([]cube.Pos, 0, 32), make(map[cube.Pos]struct{}, 32)
+	estimatedBlocks := max(32, min(4096, int(size*size*size*16)))
+	if _, ok := tx.Liquid(cube.PosFromVec3(explosionPos)); ok {
+		// Liquids such as water stop a regular TNT blast at the source, so avoid reserving space for a full blast.
+		estimatedBlocks = 32
+	}
+	affectedBlocks := make([]cube.Pos, 0, estimatedBlocks)
+	blockCache := make(map[cube.Pos]explosionBlockInfo, estimatedBlocks)
 	for _, ray := range rays {
 		pos := explosionPos
 		for blastForce := size * (0.7 + r.Float64()*0.6); blastForce > 0.0; blastForce -= 0.225 {
 			current := cube.PosFromVec3(pos)
-			currentBlock := tx.Block(current)
-
-			resistance, resists := 0.0, false
-			if l, ok := tx.Liquid(current); ok {
-				resistance, resists = l.BlastResistance(), true
-			} else if i, ok := currentBlock.(Breakable); ok {
-				resistance, resists = i.BreakInfo().BlastResistance, true
-			} else if _, ok = currentBlock.(Air); !ok {
+			info, ok := blockCache[current]
+			if !ok {
+				currentBlock := tx.Block(current)
+				if l, ok := tx.Liquid(current); ok {
+					info.resistance = l.BlastResistance()
+					info.flags = explosionBlockResists
+				} else if i, ok := currentBlock.(Breakable); ok {
+					info.resistance = i.BreakInfo().BlastResistance
+					info.flags = explosionBlockResists
+				} else if _, ok = currentBlock.(Air); !ok {
+					info.flags = explosionBlockStopsRay
+				}
+				blockCache[current] = info
+			}
+			if info.flags&explosionBlockStopsRay != 0 {
 				// Completely stop the ray if the current block is not air and unbreakable.
 				break
 			}
 
 			pos = pos.Add(ray)
 			// Air offers no resistance to the ray, only blocks and liquids reduce its force beyond the step decay.
-			if resists {
-				blastForce -= (resistance + 0.3) * 0.3
+			if info.flags&explosionBlockResists != 0 {
+				blastForce -= (info.resistance + 0.3) * 0.3
 			}
-			if blastForce > 0 {
-				if _, ok := seen[current]; !ok {
-					seen[current] = struct{}{}
-					affectedBlocks = append(affectedBlocks, current)
-				}
+			if blastForce > 0 && info.flags&explosionBlockAffected == 0 {
+				info.flags |= explosionBlockAffected
+				blockCache[current] = info
+				affectedBlocks = append(affectedBlocks, current)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Reduce explosion block-selection overhead by caching each visited position's blast resistance, ray-stop state, and affected-block state for the duration of one explosion.

Explosion rays overlap heavily. The previous traversal repeatedly read the same block/liquid, recomputed `BreakInfo().BlastResistance`, and used a second map to deduplicate affected positions. This change consolidates that work into one per-explosion cache while preserving the ordered affected-block list.

The traversal remains fully synchronous on the current world transaction. Handler timing, block mutation, item drops, entity impact, particles, and sounds are unchanged.

## Benchmarks

Apple M3 Pro, Go 1.26.2, darwin/arm64. Paired medians from 5 runs at 2 seconds per benchmark:

| Scenario | CPU before | CPU after | CPU saved | Bytes before | Bytes after | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Air | 1.179 ms | 0.382 ms | 67.6% | 230.3 KiB | 160.7 KiB | 29 | 13 |
| Stone floor | 0.896 ms | 0.283 ms | 68.4% | 174.6 KiB | 123.0 KiB | 1,224 | 61 |
| Water cube | 60.64 µs | 15.72 µs | 74.1% | 3.641 KiB | 4.016 KiB | 10 | 10 |
| 100-blast stone-floor volley | 94.23 ms | 27.88 ms | 70.4% | 17.05 MiB | 12.01 MiB | 122,442 | 6,100 |

For the 100-blast volley, the isolated selection phase saves about 66.35 ms, 5.04 MiB, and 116,342 allocations. The water-contained case is 74% faster but uses 384 additional bytes per explosion; allocation count is unchanged.

These benchmarks cancel in `HandleExplosion` after affected-block selection, so they measure the phase changed here rather than downstream breaking, drops, damage, particles, or networking. The benchmark harness and complete paired results are available in [HashimTheArab/dragonfly#60](https://github.com/HashimTheArab/dragonfly/pull/60).

## Validation

- `gofmt -w server/block/explosion.go`
- `git diff --check upstream/master...HEAD`
- `go test ./...`
- `go vet ./...`
