### PR TITLE
server/item: move the item NBT codec out of nbtconv

### DIFF
--- a/server/block/campfire.go
+++ b/server/block/campfire.go
@@ -243,7 +243,7 @@ func (c Campfire) EncodeNBT() map[string]any {
 	for i, v := range c.Items {
 		id := strconv.Itoa(i + 1)
 		if !v.Item.Empty() {
-			m["Item"+id] = nbtconv.WriteItem(v.Item, true)
+			m["Item"+id] = item.WriteNBT(v.Item, true)
 			m["ItemTime"+id] = uint8(v.Time.Milliseconds() / 50)
 		}
 	}
@@ -255,7 +255,7 @@ func (c Campfire) DecodeNBT(data map[string]any) any {
 	for i := 0; i < 4; i++ {
 		id := strconv.Itoa(i + 1)
 		c.Items[i] = CampfireItem{
-			Item: nbtconv.MapItem(data, "Item"+id),
+			Item: item.MapNBT(data, "Item"+id),
 			Time: time.Duration(nbtconv.Int16(data, "ItemTime"+id)) * time.Millisecond * 50,
 		}
 	}

--- a/server/block/decorated_pot.go
+++ b/server/block/decorated_pot.go
@@ -171,14 +171,14 @@ func (p DecoratedPot) EncodeNBT() map[string]any {
 		"sherds": sherds,
 	}
 	if !p.Item.Empty() {
-		m["item"] = nbtconv.WriteItem(p.Item, true)
+		m["item"] = item.WriteNBT(p.Item, true)
 	}
 	return m
 }
 
 // DecodeNBT ...
 func (p DecoratedPot) DecodeNBT(data map[string]any) any {
-	p.Item = nbtconv.MapItem(data, "item")
+	p.Item = item.MapNBT(data, "item")
 	p.Decorations = [4]PotDecoration{}
 	if sherds := nbtconv.Slice(data, "sherds"); sherds != nil {
 		for i, name := range sherds {

--- a/server/block/item_frame.go
+++ b/server/block/item_frame.go
@@ -118,7 +118,7 @@ func (i ItemFrame) EncodeBlock() (name string, properties map[string]any) {
 func (i ItemFrame) DecodeNBT(data map[string]any) any {
 	i.DropChance = float64(nbtconv.Float32(data, "ItemDropChance"))
 	i.Rotations = int(nbtconv.Uint8(data, "ItemRotation"))
-	i.Item = nbtconv.MapItem(data, "Item")
+	i.Item = item.MapNBT(data, "Item")
 	return i
 }
 
@@ -133,7 +133,7 @@ func (i ItemFrame) EncodeNBT() map[string]any {
 		m["id"] = "GlowItemFrame"
 	}
 	if !i.Item.Empty() {
-		m["Item"] = nbtconv.WriteItem(i.Item, true)
+		m["Item"] = item.WriteNBT(i.Item, true)
 	}
 	return m
 }

--- a/server/block/jukebox.go
+++ b/server/block/jukebox.go
@@ -3,7 +3,6 @@ package block
 import (
 	"fmt"
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/internal/nbtconv"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/sound"
@@ -109,14 +108,14 @@ func (j Jukebox) Disc() (sound.DiscType, bool) {
 func (j Jukebox) EncodeNBT() map[string]any {
 	m := map[string]any{"id": "Jukebox"}
 	if _, hasDisc := j.Disc(); hasDisc {
-		m["RecordItem"] = nbtconv.WriteItem(j.Item, true)
+		m["RecordItem"] = item.WriteNBT(j.Item, true)
 	}
 	return m
 }
 
 // DecodeNBT ...
 func (j Jukebox) DecodeNBT(data map[string]any) any {
-	s := nbtconv.MapItem(data, "RecordItem")
+	s := item.MapNBT(data, "RecordItem")
 	if _, ok := s.Item().(item.MusicDisc); ok {
 		j.Item = s
 	}

--- a/server/block/lectern.go
+++ b/server/block/lectern.go
@@ -134,7 +134,7 @@ func (l Lectern) EncodeNBT() map[string]any {
 		"id":      "Lectern",
 	}
 	if r, ok := l.Book.Item().(readableBook); ok {
-		m["book"] = nbtconv.WriteItem(l.Book, true)
+		m["book"] = item.WriteNBT(l.Book, true)
 		m["totalPages"] = int32(r.TotalPages())
 	}
 	return m
@@ -143,7 +143,7 @@ func (l Lectern) EncodeNBT() map[string]any {
 // DecodeNBT ...
 func (l Lectern) DecodeNBT(m map[string]any) any {
 	l.Page = int(nbtconv.Int32(m, "page"))
-	l.Book = nbtconv.MapItem(m, "book")
+	l.Book = item.MapNBT(m, "book")
 	return l
 }
 

--- a/server/entity/firework.go
+++ b/server/entity/firework.go
@@ -2,7 +2,6 @@ package entity
 
 import (
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/internal/nbtconv"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 )
@@ -49,12 +48,12 @@ func (fireworkType) BBox(world.Entity) cube.BBox { return cube.BBox{} }
 
 func (fireworkType) DecodeNBT(m map[string]any, data *world.EntityData) {
 	conf := fireworkConf
-	conf.Firework = nbtconv.MapItem(m, "Item").Item().(item.Firework)
+	conf.Firework = item.MapNBT(m, "Item").Item().(item.Firework)
 	conf.ExistenceDuration = conf.Firework.RandomisedDuration()
 
 	data.Data = conf.New()
 }
 
 func (fireworkType) EncodeNBT(data *world.EntityData) map[string]any {
-	return map[string]any{"Item": nbtconv.WriteItem(item.NewStack(data.Data.(*FireworkBehaviour).Firework(), 1), true)}
+	return map[string]any{"Item": item.WriteNBT(item.NewStack(data.Data.(*FireworkBehaviour).Firework(), 1), true)}
 }

--- a/server/entity/item.go
+++ b/server/entity/item.go
@@ -50,7 +50,7 @@ func (itemType) BBox(world.Entity) cube.BBox {
 
 func (itemType) DecodeNBT(m map[string]any, data *world.EntityData) {
 	conf := itemConf
-	conf.Item = nbtconv.MapItem(m, "Item")
+	conf.Item = item.MapNBT(m, "Item")
 	conf.PickupDelay = time.Duration(nbtconv.Int64(m, "PickupDelay")) * (time.Second / 20)
 
 	data.Data = conf.New()
@@ -61,6 +61,6 @@ func (itemType) EncodeNBT(data *world.EntityData) map[string]any {
 	return map[string]any{
 		"Health":      int16(5),
 		"PickupDelay": int64(b.pickupDelay / (time.Second * 20)),
-		"Item":        nbtconv.WriteItem(b.Item(), true),
+		"Item":        item.WriteNBT(b.Item(), true),
 	}
 }

--- a/server/entity/item_behaviour.go
+++ b/server/entity/item_behaviour.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/internal/nbtconv"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
@@ -38,7 +37,7 @@ func (conf ItemBehaviourConfig) New() *ItemBehaviour {
 	if i.Count() > i.MaxCount() {
 		i = i.Grow(i.MaxCount() - i.Count())
 	}
-	i = nbtconv.Item(nbtconv.WriteItem(i, true), nil)
+	i = item.ReadNBT(item.WriteNBT(i, true), nil)
 
 	if conf.PickupDelay == 0 {
 		conf.PickupDelay = time.Second / 2

--- a/server/internal/nbtconv/item.go
+++ b/server/internal/nbtconv/item.go
@@ -1,6 +1,7 @@
 package nbtconv
 
 import (
+	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/item/inventory"
 )
 
@@ -8,7 +9,7 @@ import (
 func InvFromNBT(inv *inventory.Inventory, items []any) {
 	for _, itemData := range items {
 		data, _ := itemData.(map[string]any)
-		it := Item(data, nil)
+		it := item.ReadNBT(data, nil)
 		if it.Empty() {
 			continue
 		}
@@ -23,7 +24,7 @@ func InvToNBT(inv *inventory.Inventory) []any {
 		if i.Empty() {
 			continue
 		}
-		data := WriteItem(i, true)
+		data := item.WriteNBT(i, true)
 		data["Slot"] = byte(index)
 		items = append(items, data)
 	}

--- a/server/internal/nbtconv/read.go
+++ b/server/internal/nbtconv/read.go
@@ -1,8 +1,6 @@
 package nbtconv
 
 import (
-	"bytes"
-	"encoding/gob"
 	"time"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
@@ -142,33 +140,12 @@ func PosToInt32Slice(x cube.Pos) []int32 {
 // MapItem converts an item's name, count, damage (and properties when it is a block) in a map obtained by decoding NBT
 // to a world.Item.
 func MapItem(x map[string]any, k string) item.Stack {
-	if m, ok := x[k].(map[string]any); ok {
-		return Item(m, nil)
-	}
-	return item.Stack{}
+	return item.MapNBT(x, k)
 }
 
 // Item decodes the data of an item into an item stack.
 func Item(data map[string]any, s *item.Stack) item.Stack {
-	disk, tag := s == nil, data
-	if disk {
-		t, ok := data["tag"].(map[string]any)
-		if !ok {
-			t = map[string]any{}
-		}
-		tag = t
-
-		a := readItemStack(data, tag)
-		s = &a
-	}
-
-	readAnvilCost(tag, s)
-	readDamage(tag, s, disk)
-	readDisplay(tag, s)
-	readDragonflyData(tag, s)
-	readEnchantments(tag, s)
-	readUnbreakable(tag, s)
-	return *s
+	return item.ReadNBT(data, s)
 }
 
 // Block decodes the data of a block into a world.Block.
@@ -180,104 +157,4 @@ func Block(m map[string]any, k string) world.Block {
 		return b
 	}
 	return nil
-}
-
-// readItemStack reads an item.Stack from the NBT in the map passed.
-func readItemStack(m, t map[string]any) item.Stack {
-	var it world.Item
-	if blockItem, ok := Block(m, "Block").(world.Item); ok {
-		it = blockItem
-	}
-	if v, ok := world.ItemByName(String(m, "Name"), Int16(m, "Damage")); ok {
-		it = v
-	}
-	if it == nil {
-		return item.Stack{}
-	}
-	if n, ok := it.(world.NBTer); ok {
-		it = n.DecodeNBT(t).(world.Item)
-	}
-	return item.NewStack(it, int(Uint8(m, "Count")))
-}
-
-// readDamage reads the damage value stored in the NBT with the Damage tag and saves it to the item.Stack passed.
-func readDamage(m map[string]any, s *item.Stack, disk bool) {
-	if disk {
-		*s = s.Damage(int(Int16(m, "Damage")))
-		return
-	}
-	*s = s.Damage(int(Int32(m, "Damage")))
-}
-
-// readAnvilCost ...
-func readAnvilCost(m map[string]any, s *item.Stack) {
-	*s = s.WithAnvilCost(int(Int32(m, "RepairCost")))
-}
-
-// readEnchantments reads the enchantments stored in the ench tag of the NBT passed and stores it into an item.Stack.
-func readEnchantments(m map[string]any, s *item.Stack) {
-	enchantments, ok := m["ench"].([]map[string]any)
-	if !ok {
-		for _, e := range Slice(m, "ench") {
-			if v, ok := e.(map[string]any); ok {
-				enchantments = append(enchantments, v)
-			}
-		}
-	}
-	for _, ench := range enchantments {
-		if t, ok := item.EnchantmentByID(int(Int16(ench, "id"))); ok {
-			*s = s.WithForcedEnchantments(item.NewEnchantment(t, int(Int16(ench, "lvl"))))
-		}
-	}
-}
-
-// readDisplay reads the display data present in the display field in the NBT. It includes a custom name of the item
-// and the lore.
-func readDisplay(m map[string]any, s *item.Stack) {
-	if display, ok := m["display"].(map[string]any); ok {
-		if name, ok := display["Name"].(string); ok {
-			// Only add the custom name if actually set.
-			*s = s.WithCustomName(name)
-		}
-		if lore, ok := display["Lore"].([]string); ok {
-			*s = s.WithLore(lore...)
-		} else if lore, ok := display["Lore"].([]any); ok {
-			loreLines := make([]string, 0, len(lore))
-			for _, l := range lore {
-				loreLines = append(loreLines, l.(string))
-			}
-			*s = s.WithLore(loreLines...)
-		}
-	}
-}
-
-// readDragonflyData reads data written to the dragonflyData field in the NBT of an item and adds it to the item.Stack
-// passed.
-func readDragonflyData(m map[string]any, s *item.Stack) {
-	if customData, ok := m["dragonflyData"]; ok {
-		d, ok := customData.([]byte)
-		if !ok {
-			if itf, ok := customData.([]any); ok {
-				for _, v := range itf {
-					b, _ := v.(byte)
-					d = append(d, b)
-				}
-			}
-		}
-		var values []mapValue
-		if err := gob.NewDecoder(bytes.NewBuffer(d)).Decode(&values); err != nil {
-			panic("error decoding item user data: " + err.Error())
-		}
-		for _, val := range values {
-			*s = s.WithValue(val.K, val.V)
-		}
-	}
-}
-
-// readUnbreakable reads the unbreakable value stored in the NBT with the Unbreakable tag and saves it to the item.Stack
-// passed.
-func readUnbreakable(m map[string]any, s *item.Stack) {
-	if Bool(m, "Unbreakable") {
-		*s = s.AsUnbreakable()
-	}
 }

--- a/server/internal/nbtconv/read.go
+++ b/server/internal/nbtconv/read.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
 	"golang.org/x/exp/constraints"
@@ -135,17 +134,6 @@ func Pos(x map[string]any, k string) cube.Pos {
 // PosToInt32Slice converts a cube.Pos to a []int32 with 3 elements.
 func PosToInt32Slice(x cube.Pos) []int32 {
 	return []int32{int32(x[0]), int32(x[1]), int32(x[2])}
-}
-
-// MapItem converts an item's name, count, damage (and properties when it is a block) in a map obtained by decoding NBT
-// to a world.Item.
-func MapItem(x map[string]any, k string) item.Stack {
-	return item.MapNBT(x, k)
-}
-
-// Item decodes the data of an item into an item stack.
-func Item(data map[string]any, s *item.Stack) item.Stack {
-	return item.ReadNBT(data, s)
 }
 
 // Block decodes the data of a block into a world.Block.

--- a/server/internal/nbtconv/write.go
+++ b/server/internal/nbtconv/write.go
@@ -1,41 +1,14 @@
 package nbtconv
 
 import (
-	"bytes"
-	"encoding/gob"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/chunk"
-	"sort"
 )
 
 // WriteItem encodes an item stack into a map that can be encoded using NBT.
 func WriteItem(s item.Stack, disk bool) map[string]any {
-	tag := make(map[string]any)
-	if s.Empty() {
-		return tag
-	}
-	if nbt, ok := s.Item().(world.NBTer); ok {
-		for k, v := range nbt.EncodeNBT() {
-			tag[k] = v
-		}
-	}
-	writeAnvilCost(tag, s)
-	writeDamage(tag, s, disk)
-	writeDisplay(tag, s)
-	writeDragonflyData(tag, s)
-	writeEnchantments(tag, s)
-	writeUnbreakable(tag, s)
-
-	data := make(map[string]any)
-	if disk {
-		writeItemStack(data, tag, s)
-	} else {
-		for k, v := range tag {
-			data[k] = v
-		}
-	}
-	return data
+	return item.WriteNBT(s, disk)
 }
 
 // WriteBlock encodes a world.Block into a map that can be encoded using NBT.
@@ -45,115 +18,5 @@ func WriteBlock(b world.Block) map[string]any {
 		"name":    name,
 		"states":  properties,
 		"version": chunk.CurrentBlockVersion,
-	}
-}
-
-// writeItemStack writes the name, metadata value, count and NBT of an item to a map ready for NBT encoding.
-func writeItemStack(m, t map[string]any, s item.Stack) {
-	m["Name"], m["Damage"] = s.Item().EncodeItem()
-	if b, ok := s.Item().(world.Block); ok {
-		v := map[string]any{}
-		writeBlock(v, b)
-		m["Block"] = v
-	}
-	m["Count"] = byte(s.Count())
-	if len(t) > 0 {
-		m["tag"] = t
-	}
-}
-
-// writeBlock writes the name, properties and version of a block to a map ready for NBT encoding.
-func writeBlock(m map[string]any, b world.Block) {
-	m["name"], m["states"] = b.EncodeBlock()
-	m["version"] = chunk.CurrentBlockVersion
-}
-
-// writeDragonflyData writes additional data associated with an item.Stack to a map for NBT encoding.
-func writeDragonflyData(m map[string]any, s item.Stack) {
-	if v := s.Values(); len(v) != 0 {
-		buf := new(bytes.Buffer)
-		if err := gob.NewEncoder(buf).Encode(mapToSlice(v)); err != nil {
-			panic("error encoding item user data: " + err.Error())
-		}
-		m["dragonflyData"] = buf.Bytes()
-	}
-}
-
-// mapToSlice converts a map to a slice of the type mapValue and orders the slice by the keys in the map to ensure a
-// deterministic order.
-func mapToSlice(m map[string]any) []mapValue {
-	values := make([]mapValue, 0, len(m))
-	for k, v := range m {
-		values = append(values, mapValue{K: k, V: v})
-	}
-	sort.Slice(values, func(i, j int) bool {
-		return values[i].K < values[j].K
-	})
-	return values
-}
-
-// mapValue represents a value in a map. It is used to convert maps to a slice and order the slice before encoding to
-// NBT to ensure a deterministic output.
-type mapValue struct {
-	K string
-	V any
-}
-
-// writeEnchantments writes the enchantments of an item to a map for NBT encoding.
-func writeEnchantments(m map[string]any, s item.Stack) {
-	if len(s.Enchantments()) != 0 {
-		var enchantments []map[string]any
-		for _, e := range s.Enchantments() {
-			if eType, ok := item.EnchantmentID(e.Type()); ok {
-				enchantments = append(enchantments, map[string]any{
-					"id":  int16(eType),
-					"lvl": int16(e.Level()),
-				})
-			}
-		}
-		m["ench"] = enchantments
-	}
-}
-
-// writeDisplay writes the display name and lore of an item to a map for NBT encoding.
-func writeDisplay(m map[string]any, s item.Stack) {
-	name, lore := s.CustomName(), s.Lore()
-	v := map[string]any{}
-	if name != "" {
-		v["Name"] = name
-	}
-	if len(lore) != 0 {
-		v["Lore"] = lore
-	}
-	if len(v) != 0 {
-		m["display"] = v
-	}
-}
-
-// writeDamage writes the damage to an item.Stack (either an int16 for disk or int32 for network) to a map for NBT
-// encoding.
-func writeDamage(m map[string]any, s item.Stack, disk bool) {
-	if v, ok := m["Damage"]; !ok || v.(int16) == 0 {
-		if _, ok := s.Item().(item.Durable); ok {
-			if disk {
-				m["Damage"] = int16(s.MaxDurability() - s.Durability())
-			} else {
-				m["Damage"] = int32(s.MaxDurability() - s.Durability())
-			}
-		}
-	}
-}
-
-// writeAnvilCost ...
-func writeAnvilCost(m map[string]any, s item.Stack) {
-	if cost := s.AnvilCost(); cost > 0 {
-		m["RepairCost"] = int32(cost)
-	}
-}
-
-// writeUnbreakable writes the unbreakable tag to an item stack if it is unbreakable.
-func writeUnbreakable(m map[string]any, s item.Stack) {
-	if s.Unbreakable() {
-		m["Unbreakable"] = byte(1)
 	}
 }

--- a/server/internal/nbtconv/write.go
+++ b/server/internal/nbtconv/write.go
@@ -1,15 +1,9 @@
 package nbtconv
 
 import (
-	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/chunk"
 )
-
-// WriteItem encodes an item stack into a map that can be encoded using NBT.
-func WriteItem(s item.Stack, disk bool) map[string]any {
-	return item.WriteNBT(s, disk)
-}
 
 // WriteBlock encodes a world.Block into a map that can be encoded using NBT.
 func WriteBlock(b world.Block) map[string]any {

--- a/server/item/crossbow.go
+++ b/server/item/crossbow.go
@@ -2,7 +2,6 @@ package item
 
 import (
 	"time"
-	_ "unsafe"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/world"
@@ -226,24 +225,14 @@ func (Crossbow) EncodeItem() (name string, meta int16) {
 
 // DecodeNBT ...
 func (c Crossbow) DecodeNBT(data map[string]any) any {
-	c.Item = mapItem(data, "chargedItem")
+	c.Item = MapNBT(data, "chargedItem")
 	return c
 }
 
 // EncodeNBT ...
 func (c Crossbow) EncodeNBT() map[string]any {
 	if !c.Item.Empty() {
-		return map[string]any{"chargedItem": writeItem(c.Item, true)}
+		return map[string]any{"chargedItem": WriteNBT(c.Item, true)}
 	}
 	return nil
 }
-
-// noinspection ALL
-//
-//go:linkname writeItem github.com/df-mc/dragonfly/server/internal/nbtconv.WriteItem
-func writeItem(s Stack, disk bool) map[string]any
-
-// noinspection ALL
-//
-//go:linkname mapItem github.com/df-mc/dragonfly/server/internal/nbtconv.MapItem
-func mapItem(x map[string]any, k string) Stack

--- a/server/item/nbt.go
+++ b/server/item/nbt.go
@@ -1,0 +1,337 @@
+package item
+
+import (
+	"bytes"
+	"encoding/gob"
+	"sort"
+
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/df-mc/dragonfly/server/world/chunk"
+)
+
+// WriteNBT encodes a Stack into a map that can be encoded using NBT. disk
+// selects the disk format over the network one, which differ in how an item's
+// damage is written and in whether the stack is wrapped with its name and count.
+func WriteNBT(s Stack, disk bool) map[string]any {
+	tag := make(map[string]any)
+	if s.Empty() {
+		return tag
+	}
+	if nbt, ok := s.Item().(world.NBTer); ok {
+		for k, v := range nbt.EncodeNBT() {
+			tag[k] = v
+		}
+	}
+	writeAnvilCost(tag, s)
+	writeDamage(tag, s, disk)
+	writeDisplay(tag, s)
+	writeDragonflyData(tag, s)
+	writeEnchantments(tag, s)
+	writeUnbreakable(tag, s)
+
+	data := make(map[string]any)
+	if disk {
+		writeItemStack(data, tag, s)
+	} else {
+		for k, v := range tag {
+			data[k] = v
+		}
+	}
+	return data
+}
+
+// ReadNBT decodes the data of an item into an item stack. A nil s selects the
+// disk format, in which the item's name and count are read from data itself;
+// otherwise the tags are applied to the stack passed.
+func ReadNBT(data map[string]any, s *Stack) Stack {
+	disk, tag := s == nil, data
+	if disk {
+		t, ok := data["tag"].(map[string]any)
+		if !ok {
+			t = map[string]any{}
+		}
+		tag = t
+
+		a := readItemStack(data, tag)
+		s = &a
+	}
+
+	readAnvilCost(tag, s)
+	readDamage(tag, s, disk)
+	readDisplay(tag, s)
+	readDragonflyData(tag, s)
+	readEnchantments(tag, s)
+	readUnbreakable(tag, s)
+	return *s
+}
+
+// MapNBT converts an item's name, count, damage (and properties when it is a
+// block) in a map obtained by decoding NBT at key k to a Stack.
+func MapNBT(x map[string]any, k string) Stack {
+	if m, ok := x[k].(map[string]any); ok {
+		return ReadNBT(m, nil)
+	}
+	return Stack{}
+}
+
+// writeItemStack writes the name, metadata value, count and NBT of an item to a map ready for NBT encoding.
+func writeItemStack(m, t map[string]any, s Stack) {
+	m["Name"], m["Damage"] = s.Item().EncodeItem()
+	if b, ok := s.Item().(world.Block); ok {
+		v := map[string]any{}
+		writeBlock(v, b)
+		m["Block"] = v
+	}
+	m["Count"] = byte(s.Count())
+	if len(t) > 0 {
+		m["tag"] = t
+	}
+}
+
+// writeBlock writes the name, properties and version of a block to a map ready for NBT encoding.
+func writeBlock(m map[string]any, b world.Block) {
+	m["name"], m["states"] = b.EncodeBlock()
+	m["version"] = chunk.CurrentBlockVersion
+}
+
+// writeDragonflyData writes additional data associated with a Stack to a map for NBT encoding.
+func writeDragonflyData(m map[string]any, s Stack) {
+	if v := s.Values(); len(v) != 0 {
+		buf := new(bytes.Buffer)
+		if err := gob.NewEncoder(buf).Encode(mapToSlice(v)); err != nil {
+			panic("error encoding item user data: " + err.Error())
+		}
+		m["dragonflyData"] = buf.Bytes()
+	}
+}
+
+// mapToSlice converts a map to a slice of the type mapValue and orders the slice by the keys in the map to ensure a
+// deterministic order.
+func mapToSlice(m map[string]any) []mapValue {
+	values := make([]mapValue, 0, len(m))
+	for k, v := range m {
+		values = append(values, mapValue{K: k, V: v})
+	}
+	sort.Slice(values, func(i, j int) bool {
+		return values[i].K < values[j].K
+	})
+	return values
+}
+
+// mapValue represents a value in a map. It is used to convert maps to a slice and order the slice before encoding to
+// NBT to ensure a deterministic output.
+//
+// Its name and field names are part of the on-disk format: gob identifies the
+// type by name, so worlds written before this moved package still decode.
+type mapValue struct {
+	K string
+	V any
+}
+
+// writeEnchantments writes the enchantments of an item to a map for NBT encoding.
+func writeEnchantments(m map[string]any, s Stack) {
+	if len(s.Enchantments()) != 0 {
+		var enchantments []map[string]any
+		for _, e := range s.Enchantments() {
+			if eType, ok := EnchantmentID(e.Type()); ok {
+				enchantments = append(enchantments, map[string]any{
+					"id":  int16(eType),
+					"lvl": int16(e.Level()),
+				})
+			}
+		}
+		m["ench"] = enchantments
+	}
+}
+
+// writeDisplay writes the display name and lore of an item to a map for NBT encoding.
+func writeDisplay(m map[string]any, s Stack) {
+	name, lore := s.CustomName(), s.Lore()
+	v := map[string]any{}
+	if name != "" {
+		v["Name"] = name
+	}
+	if len(lore) != 0 {
+		v["Lore"] = lore
+	}
+	if len(v) != 0 {
+		m["display"] = v
+	}
+}
+
+// writeDamage writes the damage to a Stack (either an int16 for disk or int32 for network) to a map for NBT
+// encoding.
+func writeDamage(m map[string]any, s Stack, disk bool) {
+	if v, ok := m["Damage"]; !ok || v.(int16) == 0 {
+		if _, ok := s.Item().(Durable); ok {
+			if disk {
+				m["Damage"] = int16(s.MaxDurability() - s.Durability())
+			} else {
+				m["Damage"] = int32(s.MaxDurability() - s.Durability())
+			}
+		}
+	}
+}
+
+// writeAnvilCost ...
+func writeAnvilCost(m map[string]any, s Stack) {
+	if cost := s.AnvilCost(); cost > 0 {
+		m["RepairCost"] = int32(cost)
+	}
+}
+
+// writeUnbreakable writes the unbreakable tag to an item stack if it is unbreakable.
+func writeUnbreakable(m map[string]any, s Stack) {
+	if s.Unbreakable() {
+		m["Unbreakable"] = byte(1)
+	}
+}
+
+// readItemStack reads a Stack from the NBT in the map passed.
+func readItemStack(m, t map[string]any) Stack {
+	var it world.Item
+	if blockItem, ok := nbtBlock(m, "Block").(world.Item); ok {
+		it = blockItem
+	}
+	if v, ok := world.ItemByName(nbtString(m, "Name"), nbtInt16(m, "Damage")); ok {
+		it = v
+	}
+	if it == nil {
+		return Stack{}
+	}
+	if n, ok := it.(world.NBTer); ok {
+		it = n.DecodeNBT(t).(world.Item)
+	}
+	return NewStack(it, int(nbtUint8(m, "Count")))
+}
+
+// readDamage reads the damage value stored in the NBT with the Damage tag and saves it to the Stack passed.
+func readDamage(m map[string]any, s *Stack, disk bool) {
+	if disk {
+		*s = s.Damage(int(nbtInt16(m, "Damage")))
+		return
+	}
+	*s = s.Damage(int(nbtInt32(m, "Damage")))
+}
+
+// readAnvilCost ...
+func readAnvilCost(m map[string]any, s *Stack) {
+	*s = s.WithAnvilCost(int(nbtInt32(m, "RepairCost")))
+}
+
+// readEnchantments reads the enchantments stored in the ench tag of the NBT passed and stores it into a Stack.
+func readEnchantments(m map[string]any, s *Stack) {
+	enchantments, ok := m["ench"].([]map[string]any)
+	if !ok {
+		for _, e := range nbtSlice(m, "ench") {
+			if v, ok := e.(map[string]any); ok {
+				enchantments = append(enchantments, v)
+			}
+		}
+	}
+	for _, ench := range enchantments {
+		if t, ok := EnchantmentByID(int(nbtInt16(ench, "id"))); ok {
+			*s = s.WithForcedEnchantments(NewEnchantment(t, int(nbtInt16(ench, "lvl"))))
+		}
+	}
+}
+
+// readDisplay reads the display data present in the display field in the NBT. It includes a custom name of the item
+// and the lore.
+func readDisplay(m map[string]any, s *Stack) {
+	if display, ok := m["display"].(map[string]any); ok {
+		if name, ok := display["Name"].(string); ok {
+			// Only add the custom name if actually set.
+			*s = s.WithCustomName(name)
+		}
+		if lore, ok := display["Lore"].([]string); ok {
+			*s = s.WithLore(lore...)
+		} else if lore, ok := display["Lore"].([]any); ok {
+			loreLines := make([]string, 0, len(lore))
+			for _, l := range lore {
+				loreLines = append(loreLines, l.(string))
+			}
+			*s = s.WithLore(loreLines...)
+		}
+	}
+}
+
+// readDragonflyData reads data written to the dragonflyData field in the NBT of an item and adds it to the Stack
+// passed.
+func readDragonflyData(m map[string]any, s *Stack) {
+	if customData, ok := m["dragonflyData"]; ok {
+		d, ok := customData.([]byte)
+		if !ok {
+			if itf, ok := customData.([]any); ok {
+				for _, v := range itf {
+					b, _ := v.(byte)
+					d = append(d, b)
+				}
+			}
+		}
+		var values []mapValue
+		if err := gob.NewDecoder(bytes.NewBuffer(d)).Decode(&values); err != nil {
+			panic("error decoding item user data: " + err.Error())
+		}
+		for _, val := range values {
+			*s = s.WithValue(val.K, val.V)
+		}
+	}
+}
+
+// readUnbreakable reads the unbreakable value stored in the NBT with the Unbreakable tag and saves it to the Stack
+// passed.
+func readUnbreakable(m map[string]any, s *Stack) {
+	if nbtBool(m, "Unbreakable") {
+		*s = s.AsUnbreakable()
+	}
+}
+
+// The readers below mirror the exported helpers in server/internal/nbtconv.
+// They are duplicated rather than imported because nbtconv depends on this
+// package: the item codec has to live here for the dependency to point the
+// right way, and these are the only helpers it needs.
+
+// nbtBool reads a uint8 value from a map at key k and returns true if it equals 1.
+func nbtBool(m map[string]any, k string) bool { return nbtUint8(m, k) == 1 }
+
+// nbtUint8 reads a uint8 value from a map at key k.
+func nbtUint8(m map[string]any, k string) uint8 {
+	v, _ := m[k].(uint8)
+	return v
+}
+
+// nbtString reads a string value from a map at key k.
+func nbtString(m map[string]any, k string) string {
+	v, _ := m[k].(string)
+	return v
+}
+
+// nbtInt16 reads an int16 value from a map at key k.
+func nbtInt16(m map[string]any, k string) int16 {
+	v, _ := m[k].(int16)
+	return v
+}
+
+// nbtInt32 reads an int32 value from a map at key k.
+func nbtInt32(m map[string]any, k string) int32 {
+	v, _ := m[k].(int32)
+	return v
+}
+
+// nbtSlice reads a []any value from a map at key k.
+func nbtSlice(m map[string]any, k string) []any {
+	v, _ := m[k].([]any)
+	return v
+}
+
+// nbtBlock decodes the data of a block in a map at key k into a world.Block.
+func nbtBlock(m map[string]any, k string) world.Block {
+	if mk, ok := m[k].(map[string]any); ok {
+		name, _ := mk["name"].(string)
+		properties, _ := mk["states"].(map[string]any)
+		b, _ := world.BlockByName(name, properties)
+		return b
+	}
+	return nil
+}

--- a/server/player/playerdb/inventory.go
+++ b/server/player/playerdb/inventory.go
@@ -2,7 +2,6 @@ package playerdb
 
 import (
 	"bytes"
-	"github.com/df-mc/dragonfly/server/internal/nbtconv"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/sandertv/gophertunnel/minecraft/nbt"
 )
@@ -69,13 +68,13 @@ func decodeItems(encoded []jsonSlot, items []item.Stack) {
 	}
 }
 
-func encodeItem(item item.Stack) []byte {
-	if item.Empty() {
+func encodeItem(stack item.Stack) []byte {
+	if stack.Empty() {
 		return nil
 	}
 
 	var b bytes.Buffer
-	itemNBT := nbtconv.WriteItem(item, true)
+	itemNBT := item.WriteNBT(stack, true)
 	encoder := nbt.NewEncoderWithEncoding(&b, nbt.LittleEndian)
 	err := encoder.Encode(itemNBT)
 	if err != nil {
@@ -91,5 +90,5 @@ func decodeItem(data []byte) item.Stack {
 	if err != nil {
 		return item.Stack{}
 	}
-	return nbtconv.Item(itemNBT, nil)
+	return item.ReadNBT(itemNBT, nil)
 }

--- a/server/session/entity_metadata.go
+++ b/server/session/entity_metadata.go
@@ -93,7 +93,7 @@ func (s *Session) addSpecificMetadata(e any, m protocol.EntityMetadata) {
 		m[protocol.EntityDataKeyValue] = int32(o.Experience())
 	}
 	if f, ok := e.(firework); ok {
-		m[protocol.EntityDataKeyDisplayTileRuntimeID] = nbtconv.WriteItem(item.NewStack(f.Firework(), 1), false)
+		m[protocol.EntityDataKeyDisplayTileRuntimeID] = item.WriteNBT(item.NewStack(f.Firework(), 1), false)
 		if o, ok := e.(owned); ok && f.Attached() && o.Owner() != nil {
 			m[protocol.EntityDataKeyCustomDisplay] = int64(s.handleRuntimeID(o.Owner()))
 		}

--- a/server/session/player.go
+++ b/server/session/player.go
@@ -14,7 +14,6 @@ import (
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/entity"
 	"github.com/df-mc/dragonfly/server/entity/effect"
-	"github.com/df-mc/dragonfly/server/internal/nbtconv"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/item/creative"
 	"github.com/df-mc/dragonfly/server/item/inventory"
@@ -987,7 +986,7 @@ func stackFromItem(br world.BlockRegistry, it item.Stack) protocol.ItemStack {
 		HasNetworkID:   true,
 		Count:          uint16(it.Count()),
 		BlockRuntimeID: int32(blockRuntimeID),
-		NBTData:        nbtconv.WriteItem(it, false),
+		NBTData:        item.WriteNBT(it, false),
 	}
 }
 
@@ -1011,7 +1010,7 @@ func stackToItem(br world.BlockRegistry, it protocol.ItemStack) item.Stack {
 		t = nbter.DecodeNBT(it.NBTData).(world.Item)
 	}
 	s := item.NewStack(t, int(it.Count))
-	return nbtconv.Item(it.NBTData, &s)
+	return item.ReadNBT(it.NBTData, &s)
 }
 
 // instanceFromItem converts an item.Stack to its network ItemInstance representation.


### PR DESCRIPTION
`Crossbow` reaches the item stack NBT codec through `go:linkname` rather than an import, because `nbtconv` imports `item` and the import cannot go back the other way.

A linkname pull creates no dependency edge. The compiler never looks for `nbtconv`, and the linker only resolves the symbols if something else in the binary happens to import it. Anything importing `server` — a real server — gets it via `server/entity` and `server/block`, which is presumably why this has gone unnoticed. A binary that imports `server/item` on its own does not:

```go
package main

import (
	"github.com/df-mc/dragonfly/server/item"
	"github.com/df-mc/dragonfly/server/world"
)

func main() {
	var nbt world.NBTer = item.Crossbow{}
	_ = nbt.EncodeNBT()
}
```

```
github.com/df-mc/dragonfly/server/item.Crossbow.EncodeNBT: relocation target
github.com/df-mc/dragonfly/server/internal/nbtconv.WriteItem not defined
```

It bites tools and test binaries that pull in `server/item` without reaching entities or blocks. I hit it writing an item-persistence helper package.

## The change

The stack codec moves into `item`, where the type it serialises lives and where `Crossbow` can call it directly. That is the only direction the dependency can point: anything encoding a `Stack` must import `item`, so a package below `item` cannot do it, and `item` cannot import upwards.

All existing codec callers now use `item.WriteNBT`, `item.ReadNBT`, and `item.MapNBT` directly. The item-specific forwarding wrappers have been removed from `nbtconv`; its inventory helpers remain because they also encode and decode inventory slots. Both linknames and the now-unnecessary blank `unsafe` import are gone.

Net: 16 files changed, `+364 / -320`, almost all of it code moving between packages and direct call-site updates.

## Two things worth a reviewer's attention

**Duplicated map readers.** The codec needs six trivial readers (`Bool`, `Uint8`, `String`, `Int16`, `Int32`, `Slice`) plus a block decoder. They are duplicated privately in `item` as `nbtBool`, `nbtUint8` and so on rather than imported, because `nbtconv` depends on `item`. Splitting the generic half of `nbtconv` into a leaf package both could import would avoid that, at the cost of touching every call site — happy to do it that way instead if you prefer.

**`item` picks up `world/chunk`**, for `chunk.CurrentBlockVersion` in `writeBlock`. `chunk` does not import `item`, so there is no cycle, but it does widen `item`'s footprint for one constant. Moving that constant somewhere more neutral would avoid it.

## Testing

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- The reproducer above fails to link on `master` and runs on this branch.
- `mapValue` keeps its name and field names. `gob` identifies the type by name, so worlds written before this still decode — the on-disk format is unchanged.
