### PR TITLE
world/sound: add custom sounds

### DIFF
--- a/server/session/world.go
+++ b/server/session/world.go
@@ -888,6 +888,14 @@ func (s *Session) playSound(pos mgl64.Vec3, t world.Sound, disableRelative bool)
 		return
 	case sound.DecoratedPotInsertFailed:
 		pk.SoundType = packet.SoundEventDecoratedPotInsertFail
+	case sound.Custom:
+		s.writePacket(&packet.PlaySound{
+			SoundName: so.Name,
+			Position:  vec64To32(pos),
+			Volume:    float32(so.Volume),
+			Pitch:     float32(so.Pitch),
+		})
+		return
 	case sound.LightningExplode:
 		s.writePacket(&packet.PlaySound{
 			SoundName: "ambient.weather.lightning.impact",

--- a/server/world/sound/custom.go
+++ b/server/world/sound/custom.go
@@ -1,0 +1,14 @@
+package sound
+
+// Custom is a sound identified by name. It may be used to play sounds defined
+// by a resource pack.
+type Custom struct {
+	// Name is the identifier of the sound.
+	Name string
+	// Volume is the volume of the sound.
+	Volume float64
+	// Pitch is the pitch of the sound.
+	Pitch float64
+
+	sound
+}


### PR DESCRIPTION
## Summary

- add a typed custom sound with name, volume, and pitch
- encode custom sounds using the Bedrock PlaySound packet
- support both per-player and positioned world sound APIs

## Motivation

Servers using resource-pack sounds currently need to write PlaySound packets manually. This exposes custom sounds through the existing world.Sound abstraction instead.

## Validation

- go test ./server/...

No tests were added.