### PR TITLE
server: don't send empty custom item entries

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -413,9 +413,9 @@ func (srv *Server) makeBlockEntries() {
 // at startup
 func (srv *Server) makeItemComponents() {
 	custom := world.CustomItems()
-	srv.customItems = make([]protocol.ItemEntry, 0, len(custom))
+	srv.customItems = make([]protocol.ItemEntry, len(custom))
 
-	for _, it := range custom {
+	for i, it := range custom {
 		name, _ := it.EncodeItem()
 		rid, _, _ := world.ItemRuntimeID(it)
 		_, isCustomBlock := it.(world.CustomBlock)
@@ -423,13 +423,13 @@ func (srv *Server) makeItemComponents() {
 		if isCustomBlock {
 			entryVersion = protocol.ItemEntryVersionNone
 		}
-		srv.customItems = append(srv.customItems, protocol.ItemEntry{
+		srv.customItems[i] = protocol.ItemEntry{
 			Name:           name,
 			ComponentBased: !isCustomBlock,
 			RuntimeID:      int16(rid),
 			Version:        entryVersion,
 			Data:           iteminternal.Components(it),
-		})
+		}
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -413,7 +413,7 @@ func (srv *Server) makeBlockEntries() {
 // at startup
 func (srv *Server) makeItemComponents() {
 	custom := world.CustomItems()
-	srv.customItems = make([]protocol.ItemEntry, len(custom))
+	srv.customItems = make([]protocol.ItemEntry, 0, len(custom))
 
 	for _, it := range custom {
 		name, _ := it.EncodeItem()


### PR DESCRIPTION
`makeItemComponents` sizes the slice with `make([]protocol.ItemEntry, len(custom))` and then appends to it, so the item registry sent to clients begins with one zero-valued entry per custom item — empty name, runtime ID 0 — before the real ones.

```go
srv.customItems = make([]protocol.ItemEntry, 0, len(custom))
```