### PR TITLE
server/internal/blockinternal: send destroy seconds, not hardness

### DIFF
--- a/server/internal/blockinternal/components.go
+++ b/server/internal/blockinternal/components.go
@@ -4,6 +4,7 @@ import (
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/customblock"
+	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
 )
@@ -22,9 +23,12 @@ func Components(identifier string, b world.CustomBlock, blockID int32) map[strin
 			"lightLevel": int32(diffuser.LightDiffusionLevel()),
 		})
 	}
-	if breakable, ok := b.(block.Breakable); ok {
-		info := breakable.BreakInfo()
-		builder.AddComponent("minecraft:destructible_by_mining", map[string]any{"value": float32(info.Hardness)})
+	if _, ok := b.(block.Breakable); ok {
+		// The component's value is the seconds the client takes to destroy the block, not
+		// its hardness. Bedrock has no per-tool speed component, so the bare-handed
+		// duration is the only one a static definition can carry.
+		seconds := block.BreakDuration(b, item.Stack{}, block.BreakContext{}).Seconds()
+		builder.AddComponent("minecraft:destructible_by_mining", map[string]any{"value": float32(seconds)})
 	}
 	if frictional, ok := b.(block.Frictional); ok {
 		builder.AddComponent("minecraft:friction", map[string]any{"value": float32(frictional.Friction())})

--- a/server/internal/blockinternal/components.go
+++ b/server/internal/blockinternal/components.go
@@ -24,8 +24,8 @@ func Components(identifier string, b world.CustomBlock, blockID int32) map[strin
 		})
 	}
 	if _, ok := b.(block.Breakable); ok {
-		// The component's value is the seconds the client takes to destroy the block, not
-		// its hardness. Bedrock has no per-tool speed component, so the bare-handed
+		// The component's value is the seconds the client takes to destroy the block.
+		// Bedrock has no per-tool speed component, so the bare-handed
 		// duration is the only one a static definition can carry.
 		seconds := block.BreakDuration(b, item.Stack{}, block.BreakContext{}).Seconds()
 		builder.AddComponent("minecraft:destructible_by_mining", map[string]any{"value": float32(seconds)})


### PR DESCRIPTION
`minecraft:destructible_by_mining` carries the number of **seconds** the client takes to destroy a block. The component builder was writing the block's **hardness** into it, which is a different quantity.

For `block.Stone{}` (hardness 1.5) the client is told the block takes 1.5 seconds to break. The vanilla bare-handed time is 7.5 seconds, so custom blocks currently break five times too fast for a player with no matching tool.

This derives the value from `block.BreakDuration` with an empty hand instead of passing the hardness through:

| block | hardness (sent today) | bare-hand seconds (sent after) |
|---|---|---|
| `Stone` | 1.5 | 7.5 |
| `Dirt` | 0.5 | 0.75 |
| `Planks` | 2 | 3 |
| `Obsidian` | 35 | 175.05 |

Bedrock has no per-tool speed component for custom blocks — the value is a single flat time — so the bare-handed duration is the only one a static definition can carry, and it is what a client mining without a matching tool should see. The `minecraft:is_*_item_destructible` tags the builder already emits continue to control which tools are effective.

Two other implementations read the field the same way, for what it's worth: PowerNukkitX names its setter `destructibleByMining(float seconds)` and compares the value directly against a computed break duration, and Allay sets it to `Float.MAX_VALUE` when it wants the client to never finish a break locally.

No test — `blockinternal` has no test file on master, and this seemed too small to add one for. Happy to if you'd prefer.