### PR TITLE
server/session: send the player's build platform in the player list

### DIFF
--- a/server/session/session_list.go
+++ b/server/session/session_list.go
@@ -84,6 +84,7 @@ func (l *sessionList) sendSessionTo(s, to *Session) {
 			EntityUniqueID: int64(runtimeID),
 			Username:       s.conn.IdentityData().DisplayName,
 			XUID:           s.conn.IdentityData().XUID,
+			BuildPlatform:  int32(s.conn.ClientData().DeviceOS),
 			Skin:           skinToProtocol(s.joinSkin),
 		}},
 	})

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -85,6 +85,7 @@ func (s *Session) ViewEntity(e world.Entity) {
 				UUID:           v.UUID(),
 				EntityUniqueID: int64(runtimeID),
 				Username:       v.Name(),
+				BuildPlatform:  int32(protocol.DeviceDedicated),
 				Skin:           skinToProtocol(v.Skin()),
 			}}})
 		}


### PR DESCRIPTION
`PlayerListEntry.BuildPlatform` is never set, so every player list entry Dragonfly sends carries `0`.

`0` is not a valid `protocol.DeviceOS`. The constants start at `protocol.DeviceAndroid` (1), and gophertunnel itself already refuses a login whose `DeviceOS` is outside 1-15:

```go
if data.DeviceOS <= 0 || data.DeviceOS > 15 {
      return fmt.Errorf("DeviceOS must carry a value between 1 and 15, but got %v", data.DeviceOS)
}
```

Clients up to 1.26.30 ignored the invalid value. 1.26.40 validates the field while decoding the packet and closes the connection when it does not match the enum, so the client disconnects immediately after spawning with a generic `ClientDisconnection-90` error and no server-side error at all.

This makes 1.26.40 unplayable on top of #1370: the client always drops right after `joined the game`.

### How this was tracked down

- Bisected the packets sent on join: the disconnect only happens when a `PlayerList` packet containing an **Add** entry is sent. An empty entry list or a **Remove**-only entry is accepted.
- Dumped the marshalled `PlayerList` payload and hand-decoded it — the layout matched Mojang's published `PlayerListAddEntry`/`SerializedSkin` schemas exactly, so the wire format was not at fault.
- Captured a real `PlayerList` from an official Bedrock Dedicated Server 1.26.40.8 and round-tripped it through gophertunnel: byte-for-byte identical, confirming the codec is correct.
- The only meaningful difference between the BDS entry and Dragonfly's was `Build Platform`: BDS echoed the joining client's device (`1`), Dragonfly sent `0`. Setting a valid value fixes the disconnect.

### Change

Send the device the player actually joined with, taken from the login data. For the temporary entries added in `ViewEntity` for controllables that have no session of their own, fall back to `protocol.DeviceDedicated`.

Tested against a 1.26.40 Windows client on top of #1370: the player now spawns, loads chunks and plays normally.