### PR TITLE
server/player: Add HandleArmourEquip

### DIFF
--- a/server/player/armour_handler.go
+++ b/server/player/armour_handler.go
@@ -9,17 +9,30 @@ import (
 // Handler.HandleArmourEquip before an item is placed into one of the armour slots, so that equipping may be
 // prevented.
 type armourHandler struct {
-	inventory.NopHandler
-	p *Player
+	p    *Player
+	next inventory.Handler
+}
+
+func (h armourHandler) HandleTake(ctx *inventory.Context, slot int, it item.Stack) {
+	h.next.HandleTake(ctx, slot, it)
 }
 
 // HandlePlace calls Handler.HandleArmourEquip for the item being placed. Cancelling the Context passed to it
 // cancels the inventory Context too, which stops the item from being placed at all.
 func (h armourHandler) HandlePlace(ctx *inventory.Context, slot int, it item.Stack) {
+	h.next.HandlePlace(ctx, slot, it)
+	if ctx.Cancelled() || it.Empty() {
+		return
+	}
+
 	before, _ := h.p.armour.Inventory().Item(slot)
 
 	c := newContext(h.p)
 	if h.p.Handler().HandleArmourEquip(c, slot, before, it); c.Cancelled() {
 		ctx.Cancel()
 	}
+}
+
+func (h armourHandler) HandleDrop(ctx *inventory.Context, slot int, it item.Stack) {
+	h.next.HandleDrop(ctx, slot, it)
 }

--- a/server/player/armour_handler.go
+++ b/server/player/armour_handler.go
@@ -1,0 +1,25 @@
+package player
+
+import (
+	"github.com/df-mc/dragonfly/server/item"
+	"github.com/df-mc/dragonfly/server/item/inventory"
+)
+
+// armourHandler is an inventory.Handler assigned to a Player's armour inventory. It calls
+// Handler.HandleArmourEquip before an item is placed into one of the armour slots, so that equipping may be
+// prevented.
+type armourHandler struct {
+	inventory.NopHandler
+	p *Player
+}
+
+// HandlePlace calls Handler.HandleArmourEquip for the item being placed. Cancelling the Context passed to it
+// cancels the inventory Context too, which stops the item from being placed at all.
+func (h armourHandler) HandlePlace(ctx *inventory.Context, slot int, it item.Stack) {
+	before, _ := h.p.armour.Inventory().Item(slot)
+
+	c := newContext(h.p)
+	if h.p.Handler().HandleArmourEquip(c, slot, before, it); c.Cancelled() {
+		ctx.Cancel()
+	}
+}

--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -138,6 +138,10 @@ type Handler interface {
 	HandleItemPickup(ctx *Context, i *item.Stack)
 	// HandleHeldSlotChange handles the player changing the slot they are currently holding.
 	HandleHeldSlotChange(ctx *Context, from, to int)
+	// HandleArmourEquip handles an item being placed into one of the player's armour slots. It is called
+	// before the item is equipped, so ctx.Cancel() may be used to prevent it. slot is 0 for the helmet and 3
+	// for the boots.
+	HandleArmourEquip(ctx *Context, slot int, before, after item.Stack)
 	// HandleItemDrop handles the player dropping an item on the ground.
 	// ctx.Cancel() may be called to prevent the player from dropping the item.Stack passed on the ground.
 	HandleItemDrop(ctx *Context, s item.Stack)
@@ -166,6 +170,7 @@ var _ Handler = NopHandler{}
 
 func (NopHandler) HandleItemDrop(*Context, item.Stack)                                     {}
 func (NopHandler) HandleHeldSlotChange(*Context, int, int)                                 {}
+func (NopHandler) HandleArmourEquip(*Context, int, item.Stack, item.Stack)                 {}
 func (NopHandler) HandleMove(*Context, mgl64.Vec3, cube.Rotation)                          {}
 func (NopHandler) HandleJump(*Player)                                                      {}
 func (NopHandler) HandleTeleport(*Context, mgl64.Vec3)                                     {}

--- a/server/player/type.go
+++ b/server/player/type.go
@@ -28,6 +28,8 @@ func (t ptype) Open(tx *world.Tx, handle *world.EntityHandle, data *world.Entity
 		return allowedInOffhand && it.OffHand()
 	})
 
+	pd.armour.Handle(armourHandler{p: p})
+
 	if pd.s != nil {
 		pd.s.HandleInventories(tx, p, pd.inv, pd.offHand, pd.enderChest, pd.ui, pd.armour, pd.heldSlot)
 	} else {

--- a/server/player/type.go
+++ b/server/player/type.go
@@ -28,7 +28,12 @@ func (t ptype) Open(tx *world.Tx, handle *world.EntityHandle, data *world.Entity
 		return allowedInOffhand && it.OffHand()
 	})
 
-	pd.armour.Handle(armourHandler{p: p})
+	armourInventory := pd.armour.Inventory()
+	next := armourInventory.Handler()
+	if h, ok := next.(armourHandler); ok {
+		next = h.next
+	}
+	armourInventory.Handle(armourHandler{p: p, next: next})
 
 	if pd.s != nil {
 		pd.s.HandleInventories(tx, p, pd.inv, pd.offHand, pd.enderChest, pd.ui, pd.armour, pd.heldSlot)


### PR DESCRIPTION
Adds HandleArmourEquip(ctx *Context, slot int, before, after item.Stack) to
player.Handler. There is currently no way to react to a player equipping armour, so restrictions on what a player may wear are not possible without polling the armour inventory every tick.
It is called before the item is placed, so ctx.Cancel() prevents the equip rather than reverting it. The armour inventory already routes through inventory.Handler.HandlePlace on both paths a player can equip by, so no new
call sites are introduced.