### PR TITLE
session/world.go: Set BuildPlatform on AddPlayer

### DIFF
--- a/server/session/world.go
+++ b/server/session/world.go
@@ -101,6 +101,7 @@ func (s *Session) ViewEntity(e world.Entity) {
 			UUID:            v.UUID(),
 			Username:        v.Name(),
 			Yaw:             float32(yaw),
+			BuildPlatform:   int32(protocol.DeviceDedicated),
 			AbilityData: protocol.AbilityData{
 				EntityUniqueID: int64(runtimeID),
 				Layers: []protocol.AbilityLayer{{


### PR DESCRIPTION
session/world.go: Set BuildPlatform on AddPlayer
ViewEntity sent AddPlayer without BuildPlatform, leaving it at 0. DeviceOS
values start at DeviceAndroid = 1, so 0 is not a valid platform, and it
disagreed with the PlayerList entry sent immediately before it, which uses
DeviceDedicated.
Clients do not tolerate the invalid value. Every player on the server is
disconnected as soon as an AddPlayer with BuildPlatform 0 is sent, so one
player coming into view of another kicks everybody. Setting it to
DeviceDedicated, matching the PlayerList entry, stops the disconnects.