### PR TITLE
server: Use the same NetherNet identity key path as vanilla BDS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@
 /players/
 /resources/
 
-# NetherNet server identity key
-identity.pem
-nethernet_identity.pem
+# NetherNet server identity keys
+/keys

--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@
     # KeyFile is the path to the PEM file containing the P-384 ECDSA private key used to identify
     # this listener when clients connect over plain HTTP. If the file does not exist, a new key is
     # generated and saved there. If empty, a temporary key is generated and not saved.
-    KeyFile = "nethernet_identity.pem"
+    KeyFile = "keys/server_identity_key.pem"
     # Domain is the domain that may be displayed to players connecting over plain HTTP.
     Domain = "self"
 

--- a/server/conf.go
+++ b/server/conf.go
@@ -391,7 +391,7 @@ func DefaultConfig() UserConfig {
 	c := UserConfig{}
 	c.Network.Address = ":19132"
 	c.Network.Transport = "raknet"
-	c.Network.NetherNet.KeyFile, c.Network.NetherNet.Domain = "nethernet_identity.pem", "self"
+	c.Network.NetherNet.KeyFile, c.Network.NetherNet.Domain = "keys/server_identity_key.pem", "self"
 	c.Server.Name = "Dragonfly Server"
 	c.Server.AuthEnabled = true
 	c.World.SaveData = true

--- a/server/listener.go
+++ b/server/listener.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/df-mc/dragonfly/server/session"
@@ -61,8 +62,7 @@ func importPrivateKey(path string) (*ecdsa.PrivateKey, error) {
 	case "EC PRIVATE KEY":
 		key, err = x509.ParseECPrivateKey(block.Bytes)
 	case "PRIVATE KEY":
-		var parsed any
-		parsed, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+		parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 		if err != nil {
 			return nil, fmt.Errorf("parse private key: %w", err)
 		}
@@ -93,6 +93,9 @@ func exportPrivateKey(path string, key *ecdsa.PrivateKey) error {
 		Type:  "EC PRIVATE KEY",
 		Bytes: keyBytes,
 	})
+	if err := os.MkdirAll(filepath.Dir(path), 0600); err != nil {
+		return fmt.Errorf("make parent directories: %w", err)
+	}
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		return err


### PR DESCRIPTION
Bedrock Dedicated Server version 1.26.50.24 has added support for saving server identity keys via the serveridentity command.

This PR changes the default key path to `keys/server_identity_key.pem`, matching the path used by BDS.