### PR TITLE
server/entity: fix water bottles only extinguishing fire that has just been lit

### DIFF
--- a/server/entity/splashable.go
+++ b/server/entity/splashable.go
@@ -10,6 +10,13 @@ import (
 	"time"
 )
 
+// isFire checks if the block passed is fire. Fire is compared by name rather than by value: it carries an age that
+// climbs as it burns down, so a fire that has been alight for a moment is not equal to a freshly placed one.
+func isFire(b world.Block) bool {
+	name, _ := b.EncodeBlock()
+	return name == "minecraft:fire" || name == "minecraft:soul_fire"
+}
+
 // SplashableBlock is a block that can be splashed with a splash bottle.
 type SplashableBlock interface {
 	world.Block
@@ -67,12 +74,12 @@ func potionSplash(durMul float64, pot potion.Potion, linger bool) func(e *Ent, t
 			switch result := res.(type) {
 			case trace.BlockResult:
 				blockPos := result.BlockPosition().Side(result.Face())
-				if tx.Block(blockPos) == fire() {
+				if isFire(tx.Block(blockPos)) {
 					tx.SetBlock(blockPos, nil, nil)
 				}
 
 				for _, f := range cube.HorizontalFaces() {
-					if h := blockPos.Side(f); tx.Block(h) == fire() {
+					if h := blockPos.Side(f); isFire(tx.Block(h)) {
 						tx.SetBlock(h, nil, nil)
 					}
 

--- a/server/entity/splashable.go
+++ b/server/entity/splashable.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/cube/trace"
 	"github.com/df-mc/dragonfly/server/entity/effect"
@@ -9,13 +10,6 @@ import (
 	"github.com/go-gl/mathgl/mgl64"
 	"time"
 )
-
-// isFire checks if the block passed is fire. Fire is compared by name rather than by value: it carries an age that
-// climbs as it burns down, so a fire that has been alight for a moment is not equal to a freshly placed one.
-func isFire(b world.Block) bool {
-	name, _ := b.EncodeBlock()
-	return name == "minecraft:fire" || name == "minecraft:soul_fire"
-}
 
 // SplashableBlock is a block that can be splashed with a splash bottle.
 type SplashableBlock interface {
@@ -74,12 +68,13 @@ func potionSplash(durMul float64, pot potion.Potion, linger bool) func(e *Ent, t
 			switch result := res.(type) {
 			case trace.BlockResult:
 				blockPos := result.BlockPosition().Side(result.Face())
-				if isFire(tx.Block(blockPos)) {
+				if _, ok := tx.Block(blockPos).(block.Fire); ok {
 					tx.SetBlock(blockPos, nil, nil)
 				}
 
 				for _, f := range cube.HorizontalFaces() {
-					if h := blockPos.Side(f); isFire(tx.Block(h)) {
+					h := blockPos.Side(f)
+					if _, ok := tx.Block(h).(block.Fire); ok {
 						tx.SetBlock(h, nil, nil)
 					}
 


### PR DESCRIPTION
### What happens

A splash water bottle puts out fire that was just placed, but not fire that has been burning for a while. Soul fire is never extinguished.

### Why

The block hit was compared against a fire block **value**:

```go
if tx.Block(blockPos) == fire() {
```

`fire()` is `block.Fire{Age: 0, Type: NormalFire}`, and comparing whole block values means only fire with an age of exactly 0 matched. Fire ages as it burns: `fire.go:96` increments `Age` up to 15 on random ticks. Soul fire never matched either, as it differs in its type.

Fresh fire works, which is why this is easy to miss.

### What changed

Fire is recognised by name rather than by value, which covers every age and both fire types. `server/entity` cannot import `server/block` (import cycle), so the check is on the encoded block name.

### Verification

Confirmed in-game on a real client: fire that had been burning for a while was not extinguished before the fix.
