### PR TITLE
server/block: fix a lectern taking the whole stack of books used on it

### DIFF
--- a/server/block/lectern.go
+++ b/server/block/lectern.go
@@ -87,7 +87,8 @@ func (l Lectern) Activate(pos cube.Pos, _ cube.Face, tx *world.Tx, u item.User, 
 		return false
 	}
 
-	l.Book, l.Page = held, 0
+	// Only one book is taken from the stack held, so only one may be put on the lectern.
+	l.Book, l.Page = held.Grow(-held.Count()+1), 0
 	tx.SetBlock(pos, l, nil)
 
 	tx.PlaySound(pos.Vec3Centre(), sound.LecternBookPlace{})


### PR DESCRIPTION
### What happens and why

Activate stored the stack held on the lectern and then took a single book from
it, so a lectern used with a stack of books held all of them while the player
kept all but one. Taking the book off again, by punching the lectern or
breaking it, returns the whole stack: sixteen books become thirty-one.

ItemFrame.Activate takes a single item from the stack the same way.

### Verification

Reproduced by an audit against the known duplication techniques: a lectern used with sixteen books held all sixteen, and punching it off returned thirty-one in total.

No test: driving `Activate` needs a full player in a package that cannot import `server/player` without an import cycle, which is more scaffolding than the one line it would cover.