### PR TITLE
server/entity: fix how often an area effect cloud applies its effects

### DIFF
--- a/server/entity/area_effect_cloud_behaviour.go
+++ b/server/entity/area_effect_cloud_behaviour.go
@@ -98,7 +98,7 @@ func (a *AreaEffectCloudBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 		}
 	}
 
-	if int16(e.Age()/(time.Second*20))%10 != 0 {
+	if (e.Age()/(time.Second/20))%10 != 0 {
 		// Area effect clouds only trigger updates every ten ticks.
 		return nil
 	}


### PR DESCRIPTION
### What happens and why

The check meant to run the effects of a cloud every ten ticks divided the age
of the entity by twenty seconds rather than by the length of a tick, so it
counted units of four hundred ticks. The remainder is therefore zero for the
whole of the first twenty seconds, during which the effects are applied every
tick, and non-zero for the next three minutes, during which they are not
applied at all.

This is the same confusion between a tick and twenty seconds that lost several
durations when they were written to NBT.

### Verification

Found by reading, in the same family as the duration errors fixed in `fix/entity-nbt-round-trips`. The comment beside the check states the intent the arithmetic does not meet.

No test: applying the effects needs a living entity in a world, which is more scaffolding than a one line unit correction.
