### PR TITLE
server/session: fix nil dereference when viewing an entity with no armour

### DIFF
--- a/server/session/world.go
+++ b/server/session/world.go
@@ -336,7 +336,6 @@ func (s *Session) ViewEntityArmour(e world.Entity) {
 
 	inv := armoured.Armour()
 	if inv == nil {
-		// The entity has an Armour method, but carries no armour inventory.
 		return
 	}
 

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -335,6 +335,10 @@ func (s *Session) ViewEntityArmour(e world.Entity) {
 	}
 
 	inv := armoured.Armour()
+	if inv == nil {
+		// The entity has an Armour method, but carries no armour inventory.
+		return
+	}
 
 	// Show the entity's armour
 	s.writePacket(&packet.MobArmourEquipment{


### PR DESCRIPTION
### What happens and why

ViewEntityArmour asserts that an entity has an Armour method and then reads
four slots from what it returns, with no nil check. A method set belongs to a
type rather than an instance, so that assertion succeeds for every instance of
a type that has the method, including ones carrying no armour. Returning nil
for those is the obvious implementation and there is nothing in the interface
to warn against it.

The call is reached from showEntity, which runs for every entity brought into
view, so a single such entity panics the world transaction as soon as a player
comes near it. Transactions recover from panics, so the world survives and the
entity is left half added, with the cause only visible in the log.

No entity in dragonfly returns nil here: the only type in the tree with this
method is Player, whose armour inventory is filled in before the entity
exists. This is reachable only from entity types defined outside dragonfly.

### How to reach it

Any entity type outside dragonfly that declares the method and has no armour to report:

```go
func (e *myEntity) Armour() *inventory.Armour { return nil }
```

`ViewEntityArmour` asserts an anonymous interface, and a method set belongs to the type rather than to the instance, so that assertion succeeds for every instance of such a type. It then reads four slots from the result without checking it:

```go
armoured, ok := e.(interface{ Armour() *inventory.Armour })
if !ok {
    return
}
inv := armoured.Armour()
... instanceFromItem(s.br, inv.Helmet())
```

`showEntity` calls it for every entity brought into view, so the entity only has to be spawned near a player.

```
panic: runtime error: invalid memory address or nil pointer dereference
inventory.(*Armour).Helmet(...)            server/item/inventory/armour.go:70
session.(*Session).ViewEntityArmour(...)   server/session/world.go:342
world.showEntity(...)                      server/world/world.go:1344
world.(*World).addEntityAt(...)            server/world/world.go:857
```

### What it costs, and what it does not

The panic happens inside a world transaction, which recovers, so the process survives: the result is a logged panic and an `AddEntity` that never completed, leaving the entity half added. It is not the process kill I first described it as.

No entity in dragonfly can trigger it. The only type in the tree with this method is `Player`, whose armour inventory is filled in by `fillDefaults` before the entity exists, so this is reachable only from entity types defined outside dragonfly. Returning nil for an entity that is never dressed is the obvious implementation, and nothing in the interface warns against it.

### Verification

Reproduced in process by spawning an entity of such a type into a world with a viewer, which produced the stack above. There is no test on this branch: standing up an entity type and a session to reach a three line nil check is more scaffolding than the change it would cover.